### PR TITLE
Verify Git Tag and package version before pushing

### DIFF
--- a/.github/scripts/verify_tag_and_version.py
+++ b/.github/scripts/verify_tag_and_version.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Verify the version of the Package with the version in Git tag."""
+
+import os
+import re
+from pathlib import Path
+
+repo_dir = Path(__file__).parent.parent.parent
+
+path_of_init_file = Path(repo_dir / "fivetran_provider_async" / "__init__.py")
+version_file = path_of_init_file.read_text()
+git_ref = os.getenv("GITHUB_REF", "")
+git_tag = git_ref.replace("refs/tags/", "")
+version = re.findall('__version__ = "(.*)"', version_file)[0]
+
+if git_tag is not None:
+    if version != git_tag:
+        raise SystemExit(
+            f"The version in {path_of_init_file} ({version}) does not match the Git Tag ({git_tag})."
+        )

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
       with:
         path: ~/.cache/pip
         key: ${{ hashFiles('setup.cfg') }}
+    - name: Verify Git Tag and package version
+      run: python3 .github/scripts/verify_tag_and_version.py
     - run: pip3 install -U pip wheel build twine
     - run: python3 -m build
     - run: twine check dist/*


### PR DESCRIPTION
This will give us more confidence and avoid cases where we might forget to update the version in the repo 