### PR TITLE
Correct `FivetranOperatorAsync` param name in docstring

### DIFF
--- a/fivetran_provider_async/operators.py
+++ b/fivetran_provider_async/operators.py
@@ -18,7 +18,7 @@ class FivetranOperatorAsync(FivetranOperator):
         the hook.
     :param connector_id: ID of the Fivetran connector to sync, found on the
         Connector settings page in the Fivetran Dashboard.
-    :param poke_interval: Time in seconds that the job should wait in
+    :param poll_frequency: Time in seconds that the job should wait in
         between each tries
     """
 


### PR DESCRIPTION
The current docstring notes that there is a param called `poke_interval` to poll for Fivetran job status. This parameter is actually called `poll_frequency` from the legacy `FivetranOperator`.