### PR TITLE
Update Snowflake naming and casing in extractor

### DIFF
--- a/fivetran_provider_async/utils/operator_utils.py
+++ b/fivetran_provider_async/utils/operator_utils.py
@@ -72,7 +72,7 @@ def _get_openlineage_name(config, service, schema, table) -> str:
     elif service == "google_sheets":
         return schema["name_in_destination"]
     elif service == "snowflake" or service == "redshift":
-        return f"{config['database']}.{schema['name_in_destination']}.{table}"
+        return f"{config['database']}.{schema['name_in_destination']}.{table}".lower()
     # TODO: find where dataset and table are returned in Fivetran API response for BigQuery
     # elif service == "bigquery":
     #    return f"{config['project_id']}.{}.{}}"
@@ -96,7 +96,7 @@ def _get_openlineage_namespace(config, service, connector_id) -> str:
     """
     if service == "snowflake":
         name_split = config["host"].split(".")
-        return f"snowflake://{name_split[0]}.{name_split[1]}"
+        return f"snowflake://{name_split[0]}.{name_split[1]}.{config['snowflake_cloud']}".lower()
     elif service == "gcs":
         return f"gs://{config['bucket']}"
     elif service == "redshift":

--- a/tests/utils/test_operator_utils.py
+++ b/tests/utils/test_operator_utils.py
@@ -81,7 +81,7 @@ class TestFivetranUtils(unittest.TestCase):
             ),
             table="subscription_periods",
         )
-        assert openlineage_name_snowflake_downstream == "TEST.demo.subscription_periods"
+        assert openlineage_name_snowflake_downstream == "test.demo.subscription_periods"
 
     def test_utils_get_openlineage_namespace(self):
         namespace_sheets = _get_openlineage_namespace(
@@ -96,7 +96,7 @@ class TestFivetranUtils(unittest.TestCase):
             service=MOCK_FIVETRAN_DESTINATIONS_RESPONSE_PAYLOAD_GCS_TO_SNOWFLAKE["data"]["service"],
             connector_id=CONNECTOR_ID_GCS_TO_SNOWFLAKE,
         )
-        assert namespace_snowflake == "snowflake://hq12345.us-east-1"
+        assert namespace_snowflake == "snowflake://hq12345.us-east-1.aws"
 
         namespace_gcs = _get_openlineage_namespace(
             config=MOCK_FIVETRAN_CONNECTOR_RESPONSE_PAYLOAD_GCS_TO_SNOWFLAKE["data"]["config"],


### PR DESCRIPTION
With OpenLineage [PR #1527](https://github.com/OpenLineage/OpenLineage/pull/1527) the naming convention with Snowflake was changed to use lowercasing throughout and include the hosting cloud in the namespace. The operator_utils here have been updated to reflect this change.

Signed-off-by: Benji Lampel <benjamin@astronomer.io>