### PR TITLE
Add FivetranOperatorAsync hook and trigger to handle reschedule changes

### DIFF
--- a/fivetran_provider_async/hooks.py
+++ b/fivetran_provider_async/hooks.py
@@ -106,7 +106,7 @@ class FivetranHookAsync(FivetranHook):
             initialization.
         :type previous_completed_at: pendulum.datetime.DateTime
         :param reschedule_time: Optional, if connector is in reset state
-            number of seconds to wait before restarting, else Fivetran suggestion used
+            number of seconds to wait before restarting, else uses Fivetran suggestion
         :type reschedule_time: int
         """
         connector_details = await self.get_connector_async(connector_id)

--- a/fivetran_provider_async/hooks.py
+++ b/fivetran_provider_async/hooks.py
@@ -132,7 +132,11 @@ class FivetranHookAsync(FivetranHook):
         # or manually specified, then restart sync
         if sync_state == "rescheduled" and connector_details["schedule_type"] == "manual":
             self.log.info('Connector is in "rescheduled" state and needs to be manually restarted')
-            self.pause_and_restart(connector_details["status"]["rescheduled_for"], reschedule_time)
+            self.pause_and_restart(
+                connector_id=connector_id,
+                reschedule_for=connector_details["status"]["rescheduled_for"],
+                reschedule_time=reschedule_time,
+            )
             return False
 
         # Check if sync started by airflow has finished

--- a/fivetran_provider_async/hooks.py
+++ b/fivetran_provider_async/hooks.py
@@ -176,7 +176,8 @@ class FivetranHookAsync(FivetranHook):
             ).seconds
             if wait_time < 0:
                 raise ValueError(
-                    f"Wait time of {wait_time} suggested by Fivetran has passed. Sync connector manually."
+                    f"Reschedule time {wait_time} configured in "
+                    f"Fivetran connector has elapsed. Sync connector manually."
                 )
             log_statement = f'Starting connector again in "{wait_time}" seconds'
             self.log.info(log_statement)

--- a/fivetran_provider_async/operators.py
+++ b/fivetran_provider_async/operators.py
@@ -23,7 +23,7 @@ class FivetranOperatorAsync(FivetranOperator):
     :param connector_id: ID of the Fivetran connector to sync, found on the Connector settings page.
     :param schedule_type: schedule type. Default is "manual" which takes the connector off Fivetran schedule.
     :param poll_frequency: Time in seconds that the job should wait in between each try.
-    :param reschedule_time: Optional, if connector is in reset state,
+    :param reschedule_wait_time: Optional, if connector is in reset state,
             number of seconds to wait before restarting the sync.
     """
 
@@ -37,7 +37,7 @@ class FivetranOperatorAsync(FivetranOperator):
         fivetran_retry_delay: int = 1,
         poll_frequency: int = 15,
         schedule_type: str = "manual",
-        reschedule_time: int = 0,
+        reschedule_wait_time: int = 0,
         **kwargs,
     ):
         self.connector_id = connector_id
@@ -48,7 +48,7 @@ class FivetranOperatorAsync(FivetranOperator):
         self.fivetran_retry_delay = fivetran_retry_delay
         self.poll_frequency = poll_frequency
         self.schedule_type = schedule_type
-        self.reschedule_time = reschedule_time
+        self.reschedule_wait_time = reschedule_wait_time
         super().__init__(
             connector_id=self.connector_id,
             run_name=self.run_name,
@@ -75,7 +75,7 @@ class FivetranOperatorAsync(FivetranOperator):
                 fivetran_conn_id=self.fivetran_conn_id,
                 connector_id=self.connector_id,
                 poke_interval=self.poll_frequency,
-                reschedule_time=self.reschedule_time,
+                reschedule_wait_time=self.reschedule_wait_time,
             ),
             method_name="execute_complete",
         )

--- a/fivetran_provider_async/operators.py
+++ b/fivetran_provider_async/operators.py
@@ -23,8 +23,8 @@ class FivetranOperatorAsync(FivetranOperator):
     :param connector_id: ID of the Fivetran connector to sync, found on the Connector settings page.
     :param schedule_type: schedule type. Default is "manual" which takes the connector off Fivetran schedule.
     :param poll_frequency: Time in seconds that the job should wait in between each try.
-    :param reschedule_time: Optional, if connector is in reset state
-            number of seconds to wait before restarting, else Fivetran suggestion used
+    :param reschedule_time: Optional, if connector is in reset state,
+            number of seconds to wait before restarting the sync.
     """
 
     def __init__(

--- a/fivetran_provider_async/operators.py
+++ b/fivetran_provider_async/operators.py
@@ -15,13 +15,51 @@ class FivetranOperatorAsync(FivetranOperator):
     the sync job to start. You can find `connector_id` in the Settings page of the connector
     you configured in the `Fivetran dashboard <https://fivetran.com/dashboard/connectors>`_.
 
-    :param fivetran_conn_id: `Conn ID` of the Connection to be used to configure
-        the hook.
-    :param connector_id: ID of the Fivetran connector to sync, found on the
-        Connector settings page in the Fivetran Dashboard.
-    :param poll_frequency: Time in seconds that the job should wait in
-        between each tries
+    :param fivetran_conn_id: `Conn ID` of the Connection to be used to configure the hook.
+    :param fivetran_retry_limit: # of retries when encountering API errors
+    :param fivetran_retry_delay: Time to wait before retrying API request
+    :param run_name: Fivetran run name
+    :param timeout_seconds: Timeout in seconds
+    :param connector_id: ID of the Fivetran connector to sync, found on the Connector settings page.
+    :param schedule_type: schedule type. Default is "manual" which takes the connector off Fivetran schedule.
+    :param poll_frequency: Time in seconds that the job should wait in between each try.
+    :param reschedule_time: Optional, if connector is in reset state
+            number of seconds to wait before restarting, else Fivetran suggestion used
     """
+
+    def __init__(
+        self,
+        connector_id: str,
+        run_name: Optional[str] = None,
+        timeout_seconds: Optional[int] = None,
+        fivetran_conn_id: str = "fivetran",
+        fivetran_retry_limit: int = 3,
+        fivetran_retry_delay: int = 1,
+        poll_frequency: int = 15,
+        schedule_type: str = "manual",
+        reschedule_time: int = 0,
+        **kwargs,
+    ):
+        self.connector_id = connector_id
+        self.fivetran_conn_id = fivetran_conn_id
+        self.run_name = run_name
+        self.timeout_seconds = timeout_seconds
+        self.fivetran_retry_limit = fivetran_retry_limit
+        self.fivetran_retry_delay = fivetran_retry_delay
+        self.poll_frequency = poll_frequency
+        self.schedule_type = schedule_type
+        self.reschedule_time = reschedule_time
+        super().__init__(
+            connector_id=self.connector_id,
+            run_name=self.run_name,
+            timeout_seconds=self.timeout_seconds,
+            fivetran_conn_id=self.fivetran_conn_id,
+            fivetran_retry_limit=self.fivetran_retry_limit,
+            fivetran_retry_delay=self.fivetran_retry_delay,
+            poll_frequency=self.poll_frequency,
+            schedule_type=self.schedule_type,
+            **kwargs,
+        )
 
     def execute(self, context: Dict[str, Any]) -> None:
         """Start the sync using synchronous hook"""
@@ -37,6 +75,7 @@ class FivetranOperatorAsync(FivetranOperator):
                 fivetran_conn_id=self.fivetran_conn_id,
                 connector_id=self.connector_id,
                 poke_interval=self.poll_frequency,
+                reschedule_time=self.reschedule_time,
             ),
             method_name="execute_complete",
         )

--- a/fivetran_provider_async/sensors.py
+++ b/fivetran_provider_async/sensors.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, Optional
 
 from airflow.exceptions import AirflowException
 from airflow.utils.context import Context
+from airflow.utils.decorators import apply_defaults
 from fivetran_provider.sensors.fivetran import FivetranSensor
 
 from fivetran_provider_async.triggers import FivetranTrigger
@@ -30,6 +31,7 @@ class FivetranSensorAsync(FivetranSensor):
             number of seconds to wait before restarting, else Fivetran suggestion used
     """
 
+    @apply_defaults
     def __init__(
         self,
         connector_id: str,
@@ -56,7 +58,6 @@ class FivetranSensorAsync(FivetranSensor):
             poke_interval=self.poke_interval,
             fivetran_retry_limit=self.fivetran_retry_limit,
             fivetran_retry_delay=self.fivetran_retry_delay,
-            hook=self.hook,
             xcom=self.xcom,
             **kwargs,
         )

--- a/fivetran_provider_async/sensors.py
+++ b/fivetran_provider_async/sensors.py
@@ -26,7 +26,40 @@ class FivetranSensorAsync(FivetranSensor):
         between each tries
     :param fivetran_retry_limit: # of retries when encountering API errors
     :param fivetran_retry_delay: Time to wait before retrying API request
+    :param reschedule_time: Optional, if connector is in reset state
+            number of seconds to wait before restarting, else Fivetran suggestion used
     """
+
+    def __init__(
+        self,
+        connector_id: str,
+        fivetran_conn_id: str = "fivetran",
+        poke_interval: int = 60,
+        fivetran_retry_limit: int = 3,
+        fivetran_retry_delay: int = 1,
+        xcom: str = "",
+        reschedule_time: int = 0,
+        **kwargs: Any,
+    ) -> None:
+        self.fivetran_conn_id = fivetran_conn_id
+        self.connector_id = connector_id
+        self.poke_interval = poke_interval
+        self.previous_completed_at = None
+        self.fivetran_retry_limit = fivetran_retry_limit
+        self.fivetran_retry_delay = fivetran_retry_delay
+        self.hook = None
+        self.xcom = xcom
+        self.reschedule_time = reschedule_time
+        super().__init__(
+            connector_id=self.connector_id,
+            fivetran_conn_id=self.fivetran_conn_id,
+            poke_interval=self.poke_interval,
+            fivetran_retry_limit=self.fivetran_retry_limit,
+            fivetran_retry_delay=self.fivetran_retry_delay,
+            hook=self.hook,
+            xcom=self.xcom,
+            **kwargs,
+        )
 
     def execute(self, context: Dict[str, Any]) -> None:
         """Check for the target_status and defers using the trigger"""
@@ -39,6 +72,7 @@ class FivetranSensorAsync(FivetranSensor):
                 previous_completed_at=self.previous_completed_at,
                 xcom=self.xcom,
                 poke_interval=self.poke_interval,
+                reschedule_time=self.reschedule_time,
             ),
             method_name="execute_complete",
         )

--- a/fivetran_provider_async/sensors.py
+++ b/fivetran_provider_async/sensors.py
@@ -27,7 +27,7 @@ class FivetranSensorAsync(FivetranSensor):
         between each tries
     :param fivetran_retry_limit: # of retries when encountering API errors
     :param fivetran_retry_delay: Time to wait before retrying API request
-    :param reschedule_time: Optional, if connector is in reset state
+    :param reschedule_wait_time: Optional, if connector is in reset state
             number of seconds to wait before restarting, else Fivetran suggestion used
     """
 
@@ -40,7 +40,7 @@ class FivetranSensorAsync(FivetranSensor):
         fivetran_retry_limit: int = 3,
         fivetran_retry_delay: int = 1,
         xcom: str = "",
-        reschedule_time: int = 0,
+        reschedule_wait_time: int = 0,
         **kwargs: Any,
     ) -> None:
         self.fivetran_conn_id = fivetran_conn_id
@@ -51,7 +51,7 @@ class FivetranSensorAsync(FivetranSensor):
         self.fivetran_retry_delay = fivetran_retry_delay
         self.hook = None
         self.xcom = xcom
-        self.reschedule_time = reschedule_time
+        self.reschedule_wait_time = reschedule_wait_time
         super().__init__(
             connector_id=self.connector_id,
             fivetran_conn_id=self.fivetran_conn_id,
@@ -73,7 +73,7 @@ class FivetranSensorAsync(FivetranSensor):
                 previous_completed_at=self.previous_completed_at,
                 xcom=self.xcom,
                 poke_interval=self.poke_interval,
-                reschedule_time=self.reschedule_time,
+                reschedule_wait_time=self.reschedule_wait_time,
             ),
             method_name="execute_complete",
         )

--- a/fivetran_provider_async/triggers.py
+++ b/fivetran_provider_async/triggers.py
@@ -55,6 +55,7 @@ class FivetranTrigger(BaseTrigger):
                 "fivetran_conn_id": self.fivetran_conn_id,
                 "previous_completed_at": self.previous_completed_at,
                 "xcom": self.xcom,
+                "reschedule_time": self.reschedule_time,
             },
         )
 

--- a/fivetran_provider_async/triggers.py
+++ b/fivetran_provider_async/triggers.py
@@ -21,8 +21,8 @@ class FivetranTrigger(BaseTrigger):
     :param xcom: If used, FivetranSensorAsync receives timestamp of previously
         completed sync
     :param poke_interval:  polling period in seconds to check for the status
-    :param reschedule_time: Optional, if connector is in reset state
-            number of seconds to wait before restarting, else Fivetran suggestion used
+    :param reschedule_time: Optional, if connector is in reset state,
+            number of seconds to wait before restarting the sync.
     """
 
     def __init__(

--- a/fivetran_provider_async/triggers.py
+++ b/fivetran_provider_async/triggers.py
@@ -26,14 +26,14 @@ class FivetranTrigger(BaseTrigger):
     """
 
     def __init__(
-            self,
-            task_id: str,
-            connector_id: str,
-            fivetran_conn_id: str,
-            previous_completed_at: pendulum.DateTime | None = None,
-            xcom: str = "",
-            poke_interval: float = 4.0,
-            reschedule_time: int = 0,
+        self,
+        task_id: str,
+        connector_id: str,
+        fivetran_conn_id: str,
+        previous_completed_at: pendulum.DateTime | None = None,
+        xcom: str = "",
+        poke_interval: float = 4.0,
+        reschedule_time: int = 0,
     ):
         super().__init__()
         self.task_id = task_id
@@ -69,9 +69,7 @@ class FivetranTrigger(BaseTrigger):
                 self.previous_completed_at = await hook.get_last_sync_async(self.connector_id, self.xcom)
             while True:
                 res = await hook.get_sync_status_async(
-                    self.connector_id,
-                    self.previous_completed_at,
-                    self.reschedule_time
+                    self.connector_id, self.previous_completed_at, self.reschedule_time
                 )
                 if res == "success":
                     self.previous_completed_at = await hook.get_last_sync_async(self.connector_id)

--- a/fivetran_provider_async/triggers.py
+++ b/fivetran_provider_async/triggers.py
@@ -21,7 +21,7 @@ class FivetranTrigger(BaseTrigger):
     :param xcom: If used, FivetranSensorAsync receives timestamp of previously
         completed sync
     :param poke_interval:  polling period in seconds to check for the status
-    :param reschedule_time: Optional, if connector is in reset state,
+    :param reschedule_wait_time: Optional, if connector is in reset state,
             number of seconds to wait before restarting the sync.
     """
 
@@ -33,7 +33,7 @@ class FivetranTrigger(BaseTrigger):
         previous_completed_at: pendulum.DateTime | None = None,
         xcom: str = "",
         poke_interval: float = 4.0,
-        reschedule_time: int = 0,
+        reschedule_wait_time: int = 0,
     ):
         super().__init__()
         self.task_id = task_id
@@ -42,7 +42,7 @@ class FivetranTrigger(BaseTrigger):
         self.previous_completed_at = previous_completed_at
         self.xcom = xcom
         self.poke_interval = poke_interval
-        self.reschedule_time = reschedule_time
+        self.reschedule_wait_time = reschedule_wait_time
 
     def serialize(self) -> Tuple[str, Dict[str, Any]]:
         """Serializes FivetranTrigger arguments and classpath."""
@@ -55,7 +55,7 @@ class FivetranTrigger(BaseTrigger):
                 "fivetran_conn_id": self.fivetran_conn_id,
                 "previous_completed_at": self.previous_completed_at,
                 "xcom": self.xcom,
-                "reschedule_time": self.reschedule_time,
+                "reschedule_wait_time": self.reschedule_wait_time,
             },
         )
 
@@ -70,7 +70,7 @@ class FivetranTrigger(BaseTrigger):
                 self.previous_completed_at = await hook.get_last_sync_async(self.connector_id, self.xcom)
             while True:
                 res = await hook.get_sync_status_async(
-                    self.connector_id, self.previous_completed_at, self.reschedule_time
+                    self.connector_id, self.previous_completed_at, self.reschedule_wait_time
                 )
                 if res == "success":
                     self.previous_completed_at = await hook.get_last_sync_async(self.connector_id)

--- a/tests/common/static.py
+++ b/tests/common/static.py
@@ -1,3 +1,5 @@
+import pendulum
+
 LOGIN = "login"
 PASSWORD = "password"
 
@@ -23,6 +25,76 @@ MOCK_FIVETRAN_RESPONSE_PAYLOAD_SHEETS = {
             "is_historical_sync": False,
             "tasks": [],
             "warnings": [],
+        },
+        "config": {
+            "latest_version": "1",
+            "sheet_id": "https://docs.google.com/spreadsheets/d/.../edit#gid=...",
+            "named_range": "fivetran_test_range",
+            "authorization_method": "User OAuth",
+            "service_version": "1",
+            "last_synced_changes__utc_": "2021-03-23 20:54",
+        },
+    },
+}
+
+MOCK_FIVETRAN_RESPONSE_PAYLOAD_SHEETS_RESCHEDULE_MODE = {
+    "code": "Success",
+    "data": {
+        "id": "interchangeable_revenge",
+        "paused": False,
+        "group_id": "rarer_gradient",
+        "service": "google_sheets",
+        "service_version": 1,
+        "schema": "google_sheets.fivetran_google_sheets_spotify",
+        "connected_by": "mournful_shalt",
+        "created_at": "2021-03-05T22:58:56.238875Z",
+        "succeeded_at": "2021-03-23T20:55:12.670390Z",
+        "failed_at": "2021-03-22T20:55:12.670390Z",
+        "sync_frequency": 360,
+        "schedule_type": "manual",
+        "status": {
+            "setup_state": "connected",
+            "sync_state": "rescheduled",
+            "update_state": "on_schedule",
+            "is_historical_sync": False,
+            "tasks": [],
+            "warnings": [],
+            "rescheduled_for": "2021-03-05T22:59:56.238875Z",
+        },
+        "config": {
+            "latest_version": "1",
+            "sheet_id": "https://docs.google.com/spreadsheets/d/.../edit#gid=...",
+            "named_range": "fivetran_test_range",
+            "authorization_method": "User OAuth",
+            "service_version": "1",
+            "last_synced_changes__utc_": "2021-03-23 20:54",
+        },
+    },
+}
+
+MOCK_FIVETRAN_RESPONSE_PAYLOAD_SHEETS_WITH_RESCHEDULE_FOR = {
+    "code": "Success",
+    "data": {
+        "id": "interchangeable_revenge",
+        "paused": False,
+        "group_id": "rarer_gradient",
+        "service": "google_sheets",
+        "service_version": 1,
+        "schema": "google_sheets.fivetran_google_sheets_spotify",
+        "connected_by": "mournful_shalt",
+        "created_at": "2021-03-05T22:58:56.238875Z",
+        "succeeded_at": "2021-03-23T20:55:12.670390Z",
+        "failed_at": "2021-03-22T20:55:12.670390Z",
+        "sync_frequency": 360,
+        "schedule_type": "manual",
+        "status": {
+            "setup_state": "connected",
+            "sync_state": "rescheduled",
+            "update_state": "on_schedule",
+            "is_historical_sync": False,
+            "tasks": [],
+            "warnings": [],
+            "rescheduled_for": str(pendulum.now(tz="UTC").add(minutes=1)),
         },
         "config": {
             "latest_version": "1",

--- a/tests/hooks/test_fivetran.py
+++ b/tests/hooks/test_fivetran.py
@@ -56,7 +56,7 @@ async def test_fivetran_hook_get_sync_status_async(
     result = await hook.get_sync_status_async(
         connector_id="interchangeable_revenge",
         previous_completed_at=mock_previous_completed_at,
-        reschedule_time=60,
+        reschedule_wait_time=60,
     )
     assert result == expected_result
 
@@ -86,7 +86,7 @@ async def test_fivetran_hook_pause_and_restart(mock_api_call_async_response, moc
     mock_api_call_async_response.return_value = MOCK_FIVETRAN_RESPONSE_PAYLOAD_SHEETS
 
     result = hook.pause_and_restart(
-        connector_id="interchangeable_revenge", reschedule_for="manual", reschedule_time=60
+        connector_id="interchangeable_revenge", reschedule_for="manual", reschedule_wait_time=60
     )
     assert result is True
 

--- a/tests/hooks/test_fivetran.py
+++ b/tests/hooks/test_fivetran.py
@@ -54,7 +54,9 @@ async def test_fivetran_hook_get_sync_status_async(
     hook = FivetranHookAsync(fivetran_conn_id="conn_fivetran")
     mock_api_call_async_response.return_value = MOCK_FIVETRAN_RESPONSE_PAYLOAD_SHEETS
     result = await hook.get_sync_status_async(
-        connector_id="interchangeable_revenge", previous_completed_at=mock_previous_completed_at
+        connector_id="interchangeable_revenge",
+        previous_completed_at=mock_previous_completed_at,
+        reschedule_time=60,
     )
     assert result == expected_result
 
@@ -72,6 +74,21 @@ async def test_fivetran_hook_get_sync_status_async_exception(mock_api_call_async
             connector_id="interchangeable_revenge", previous_completed_at=mock_previous_completed_at
         )
     assert "Fivetran sync for connector interchangeable_revenge failed" in str(exc.value)
+
+
+@pytest.mark.asyncio
+@mock.patch("fivetran_provider_async.hooks.FivetranHookAsync.start_fivetran_sync")
+@mock.patch("fivetran_provider_async.hooks.FivetranHookAsync._do_api_call_async")
+async def test_fivetran_hook_pause_and_restart(mock_api_call_async_response, mock_start_fivetran_sync):
+    """Tests that pause_and_restart method for manual mode with reschedule time set."""
+    hook = FivetranHookAsync(fivetran_conn_id="conn_fivetran")
+    mock_start_fivetran_sync.return_value = True
+    mock_api_call_async_response.return_value = MOCK_FIVETRAN_RESPONSE_PAYLOAD_SHEETS
+
+    result = hook.pause_and_restart(
+        connector_id="interchangeable_revenge", reschedule_for="manual", reschedule_time=60
+    )
+    assert result is True
 
 
 @pytest.mark.asyncio

--- a/tests/operators/test_fivetran.py
+++ b/tests/operators/test_fivetran.py
@@ -48,6 +48,29 @@ class TestFivetranOperator(unittest.TestCase):
         with pytest.raises(TaskDeferred):
             task.execute(context)
 
+    @requests_mock.mock()
+    def test_fivetran_op_async_execute_success_reschedule_wait_time_and_manual_mode(self, m):
+        """Tests that task gets deferred after job submission with reschedule wait time and manual mode."""
+        m.get(
+            "https://api.fivetran.com/v1/connectors/interchangeable_revenge",
+            json=MOCK_FIVETRAN_RESPONSE_PAYLOAD_SHEETS,
+        )
+
+        m.post(
+            "https://api.fivetran.com/v1/connectors/interchangeable_revenge/force",
+            json=MOCK_FIVETRAN_RESPONSE_PAYLOAD_SHEETS,
+        )
+
+        task = FivetranOperatorAsync(
+            task_id="fivetran_op_async",
+            fivetran_conn_id="conn_fivetran",
+            connector_id="interchangeable_revenge",
+            reschedule_wait_time=60,
+            schedule_type="manual",
+        )
+        with pytest.raises(TaskDeferred):
+            task.execute(context)
+
     def test_fivetran_op_async_execute_complete_error(self):
         """Tests that execute_complete method raises exception in case of error"""
         task = FivetranOperatorAsync(

--- a/tests/sensors/test_fivetran.py
+++ b/tests/sensors/test_fivetran.py
@@ -33,6 +33,21 @@ def test_fivetran_sensor_async():
     assert isinstance(exc.value.trigger, FivetranTrigger), "Trigger is not a FivetranTrigger"
 
 
+def test_fivetran_sensor_async_with_response_wait_time():
+    """Asserts that a task is deferred and a FivetranTrigger will be fired
+    when the FivetranSensorAsync is executed when reschedule_wait_time is specified."""
+    task = FivetranSensorAsync(
+        task_id=TASK_ID,
+        fivetran_conn_id="fivetran_default",
+        connector_id="test_connector",
+        poke_interval=5,
+        reschedule_wait_time=60,
+    )
+    with pytest.raises(TaskDeferred) as exc:
+        task.execute(context)
+    assert isinstance(exc.value.trigger, FivetranTrigger), "Trigger is not a FivetranTrigger"
+
+
 def test_fivetran_sensor_async_execute_failure(context):
     """Tests that an AirflowException is raised in case of error event"""
     task = FivetranSensorAsync(

--- a/tests/triggers/test_fivetran.py
+++ b/tests/triggers/test_fivetran.py
@@ -68,6 +68,7 @@ def test_fivetran_trigger_serialization():
         "previous_completed_at": PREV_COMPLETED_AT,
         "xcom": "",
         "task_id": "fivetran_sync_task",
+        "reschedule_time": 0,
     }
 
 

--- a/tests/triggers/test_fivetran.py
+++ b/tests/triggers/test_fivetran.py
@@ -68,7 +68,7 @@ def test_fivetran_trigger_serialization():
         "previous_completed_at": PREV_COMPLETED_AT,
         "xcom": "",
         "task_id": "fivetran_sync_task",
-        "reschedule_time": 0,
+        "reschedule_wait_time": 0,
     }
 
 


### PR DESCRIPTION
- Add FivetranOperatorAsync to handle reschedule mode
- When connector has schedule_type manual and sync_status reschedule, connector will hang as Fivetran expects manual restart. This pr automatically (or optionally manually) handles that restart.
- Add tests
closes: #21