### PR TITLE
Temporarily restrict pydantic until airflow 2.6.3 released

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,8 @@ install_requires =
     aiohttp
     asgiref
     airflow-provider-fivetran
+    # temporarily restrict pydantic until airflow 2.6.3 released
+    pydantic>=1.10.0,<2.0.0
 
 
 [options.extras_require]


### PR DESCRIPTION
test is failing in https://github.com/astronomer/airflow-provider-fivetran-async/pull/33