### PR TITLE
Update the registry URL for FivetranOperator

### DIFF
--- a/fivetran_provider_async/operators.py
+++ b/fivetran_provider_async/operators.py
@@ -8,8 +8,7 @@ from airflow.models import BaseOperator, BaseOperatorLink
 if TYPE_CHECKING:
     from airflow.utils.context import Context
 
-from __init__ import __version__
-
+from fivetran_provider_async import __version__
 from fivetran_provider_async.hooks import FivetranHook
 from fivetran_provider_async.triggers import FivetranTrigger
 from fivetran_provider_async.utils.operator_utils import datasets

--- a/fivetran_provider_async/operators.py
+++ b/fivetran_provider_async/operators.py
@@ -8,6 +8,8 @@ from airflow.models import BaseOperator, BaseOperatorLink
 if TYPE_CHECKING:
     from airflow.utils.context import Context
 
+from __init__ import __version__
+
 from fivetran_provider_async.hooks import FivetranHook
 from fivetran_provider_async.triggers import FivetranTrigger
 from fivetran_provider_async.utils.operator_utils import datasets
@@ -21,8 +23,13 @@ class RegistryLink(BaseOperatorLink):
     def get_link(self, operator, dttm):
         """Get link to registry page."""
 
-        registry_link = "https://registry.astronomer.io/providers/{provider}/modules/{operator}"
-        return registry_link.format(provider="fivetran", operator="fivetranoperator")
+        registry_link = (
+            "https://registry.astronomer.io/providers/airflow-provider-fivetran-async/"
+            "versions/{version}/modules/FivetranOperator"
+        )
+        return registry_link.format(
+            provider="airflow-provider-fivetran-async", operator="FivetranOperator", version=__version__
+        )
 
 
 class FivetranOperator(BaseOperator):

--- a/fivetran_provider_async/operators.py
+++ b/fivetran_provider_async/operators.py
@@ -22,12 +22,9 @@ class RegistryLink(BaseOperatorLink):
     def get_link(self, operator, dttm):
         """Get link to registry page."""
 
-        registry_link = (
-            "https://registry.astronomer.io/providers/airflow-provider-fivetran-async/"
-            "versions/{version}/modules/FivetranOperator"
-        )
-        return registry_link.format(
-            provider="airflow-provider-fivetran-async", operator="FivetranOperator", version=__version__
+        return (
+            f"https://registry.astronomer.io/providers/airflow-provider-fivetran-async/versions/"
+            f"{__version__}/modules/FivetranOperator"
         )
 
 


### PR DESCRIPTION
This PR corrects the registry URL FivetranOperator.

closes: https://github.com/astronomer/airflow-provider-fivetran-async/issues/29