### PR TITLE
Add mypy + some other misc. changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       - run: pip install -U pip wheel
       - run: pip install -e '.[tests]'
       - run: pip install -e '.[openlineage]'
+      - run: mypy fivetran_provider_async/ --exclude "fivetran_provider_async/example_dags/*"
       - run: pytest --junit-xml=test-report/report.xml tests
 
   build-n-publish:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,13 @@ repos:
       - id: isort
         args: ["--profile=black"]
 
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: 'v1.5.1'
+    hooks:
+      - id: mypy
+        additional_dependencies:
+          - types-requests
+
   - repo: https://github.com/pycqa/flake8
     rev: 6.1.0
     hooks:

--- a/fivetran_provider_async/__init__.py
+++ b/fivetran_provider_async/__init__.py
@@ -7,8 +7,8 @@ log = logging.getLogger(__name__)
 
 
 try:
-    from openlineage.airflow.extractors.base import (
-        OperatorLineage,  # type: ignore[import]
+    from openlineage.airflow.extractors.base import (  # type: ignore[import]
+        OperatorLineage,
     )
     from openlineage.client.facet import (
         DataSourceDatasetFacet,

--- a/fivetran_provider_async/__init__.py
+++ b/fivetran_provider_async/__init__.py
@@ -7,7 +7,9 @@ log = logging.getLogger(__name__)
 
 
 try:
-    from openlineage.airflow.extractors.base import OperatorLineage
+    from openlineage.airflow.extractors.base import (
+        OperatorLineage,  # type: ignore[import]
+    )
     from openlineage.client.facet import (
         DataSourceDatasetFacet,
         DocumentationJobFacet,

--- a/fivetran_provider_async/example_dags/example_fivetran_bqml.py
+++ b/fivetran_provider_async/example_dags/example_fivetran_bqml.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 
 from airflow import DAG
-from airflow.operators.python_operator import BranchPythonOperator
+from airflow.operators.python import BranchPythonOperator
 from airflow.providers.google.cloud.operators.bigquery import (
     BigQueryExecuteQueryOperator,
     BigQueryGetDataOperator,

--- a/fivetran_provider_async/hooks.py
+++ b/fivetran_provider_async/hooks.py
@@ -1,17 +1,23 @@
+from __future__ import annotations
+
 import asyncio
-import json
 import time
+from datetime import datetime
 from time import sleep
-from typing import Any, Dict, cast
+from typing import TYPE_CHECKING, Any, Dict
 
 import aiohttp
 import pendulum
 import requests
 from aiohttp import ClientResponseError
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.hooks.base import BaseHook
+from airflow.utils.helpers import is_container
 from asgiref.sync import sync_to_async
 from requests import exceptions as requests_exceptions
+
+if TYPE_CHECKING:
+    from airflow.models.connection import Connection
 
 
 class FivetranHook(BaseHook):
@@ -63,7 +69,7 @@ class FivetranHook(BaseHook):
         """
         Fetch and return the current Airflow version
         from aws provider
-        https://github.com/apache/airflow/blob/main/airflow/providers/amazon/aws/hooks/base_aws.py#L486
+        https://github.com/apache/airflow/blob/main/airflow/providers/amazon/aws/hooks/base_aws.py#L536
         """
         try:
             # This can be a circular import under specific configurations.
@@ -78,7 +84,7 @@ class FivetranHook(BaseHook):
     def __init__(
         self,
         fivetran_conn_id: str = "fivetran",
-        fivetran_conn=None,
+        fivetran_conn: Connection | None = None,
         timeout_seconds: int = 180,
         retry_limit: int = 3,
         retry_delay: float = 1.0,
@@ -92,52 +98,66 @@ class FivetranHook(BaseHook):
         self.retry_limit = retry_limit
         self.retry_delay = retry_delay
 
-    def _do_api_call(self, endpoint_info, json=None, headers=None):
+    def _prepare_api_call_kwargs(self, method: str, endpoint: str, **kwargs: Any) -> dict[str, Any]:
+        """Add additional data to the API call."""
+        if self.fivetran_conn is None:
+            self.fivetran_conn = self.get_connection(self.conn_id)
+
+        auth = (self.fivetran_conn.login, self.fivetran_conn.password)
+
+        kwargs.setdefault("auth", auth)
+        kwargs.setdefault("headers", {})
+
+        kwargs["headers"].setdefault("User-Agent", self.api_user_agent + self._get_airflow_version())
+
+        if method in ("POST", "PATCH"):
+            kwargs["headers"].setdefault("Content-Type", "application/json;version=2")
+
+        return kwargs
+
+    def _do_api_call(
+        self, method: str, endpoint: str = None, **kwargs: Any  # type: ignore[assignment]
+    ) -> dict[str, Any]:
         """
         Utility function to perform an API call with retries
 
-        :param endpoint_info: Tuple of method and endpoint
-        :type endpoint_info: tuple[string, string]
-        :param json: Parameters for this API call.
-        :type json: dict
-        :param json: Headers for this API call.
-        :type json: dict
+        :param method: Method for the API call
+        :param endpoint: Endpoint of the Fivetran API to be hit
+        :param kwargs: kwargs to be passed to requests.request()
         :return: If the api call returns a OK status code,
-            this function returns the response in JSON. Otherwise,
+            this function returns the response as a dict. Otherwise,
             we throw an AirflowException.
-        :rtype: dict
         """
-        method, endpoint = endpoint_info
+        if is_container(method) and len(method) == 2:
+            import warnings
+
+            warnings.warn(
+                "The API for _do_api_call() has changed to closer match the"
+                " requests.request() API. Please update your code accordingly.",
+                AirflowProviderDeprecationWarning,
+                stacklevel=2,
+            )
+            method, endpoint = method  # type: ignore[misc]
+        elif endpoint is None:
+            raise TypeError(
+                f"{self.__class__.__name__}._do_api_call() missing 1 required"
+                f" positional argument: 'endpoint'"
+            )
+
+        if TYPE_CHECKING:
+            assert endpoint is not None
+
         if self.fivetran_conn is None:
             self.fivetran_conn = self.get_connection(self.conn_id)
-        auth = (self.fivetran_conn.login, self.fivetran_conn.password)
+
         url = f"{self.api_protocol}://{self.api_host}/{endpoint}"
 
-        if headers is None:
-            headers = {}
-        headers.update({"User-Agent": self.api_user_agent + self._get_airflow_version()})
-
-        if method == "GET":
-            request_func = requests.get
-        elif method == "POST":
-            request_func = requests.post
-            headers.update({"Content-Type": "application/json;version=2"})
-        elif method == "PATCH":
-            request_func = requests.patch
-            headers.update({"Content-Type": "application/json;version=2"})
-        else:
-            raise AirflowException("Unexpected HTTP Method: " + method)
+        kwargs = self._prepare_api_call_kwargs(method, endpoint, **kwargs)
 
         attempt_num = 1
         while True:
             try:
-                response = request_func(
-                    url,
-                    data=json if method in ("POST", "PATCH") else None,
-                    params=json if method in ("GET") else None,
-                    auth=auth,
-                    headers=headers,
-                )
+                response = requests.request(method, url, **kwargs)
                 response.raise_for_status()
                 return response.json()
             except requests_exceptions.RequestException as e:
@@ -148,7 +168,7 @@ class FivetranHook(BaseHook):
                         f"Response: {e.response.content}, " f"Status Code: {e.response.status_code}"
                     )
 
-                self._log_request_error(attempt_num, e)
+                self._log_request_error(attempt_num, str(e))
 
             if attempt_num == self.retry_limit:
                 raise AirflowException(
@@ -165,48 +185,44 @@ class FivetranHook(BaseHook):
             error,
         )
 
-    def _connector_ui_url(self, service_name, schema_name):
-        return f"https://fivetran.com/dashboard/connectors/" f"{service_name}/{schema_name}"
+    def _connector_ui_url(self, service_name: str, schema_name: str) -> str:
+        return f"https://fivetran.com/dashboard/connectors/{service_name}/{schema_name}"
 
-    def _connector_ui_url_logs(self, service_name, schema_name):
+    def _connector_ui_url_logs(self, service_name: str, schema_name: str) -> str:
         return self._connector_ui_url(service_name, schema_name) + "/logs"
 
-    def _connector_ui_url_setup(self, service_name, schema_name):
+    def _connector_ui_url_setup(self, service_name: str, schema_name: str) -> str:
         return self._connector_ui_url(service_name, schema_name) + "/setup"
 
-    def get_connector(self, connector_id) -> dict:
+    def get_connector(self, connector_id: str) -> dict[str, Any]:
         """
         Fetches the detail of a connector.
 
         :param connector_id: Fivetran connector_id, found in connector settings
             page in the Fivetran user interface.
-        :type connector_id: str
         :return: connector details
-        :rtype: Dict
         """
         if connector_id == "":
             raise ValueError("No value specified for connector_id")
         endpoint = self.api_path_connectors + connector_id
-        resp = self._do_api_call(("GET", endpoint))
+        resp = self._do_api_call("GET", endpoint)
         return resp["data"]
 
-    def get_connector_schemas(self, connector_id) -> dict:
+    def get_connector_schemas(self, connector_id: str) -> dict[str, Any]:
         """
         Fetches schema information of the connector.
 
         :param connector_id: Fivetran connector_id, found in connector settings
             page in the Fivetran user interface.
-        :type connector_id: str
         :return: schema details
-        :rtype: Dict
         """
         if connector_id == "":
             raise ValueError("No value specified for connector_id")
         endpoint = self.api_path_connectors + connector_id + "/schemas"
-        resp = self._do_api_call(("GET", endpoint))
+        resp = self._do_api_call("GET", endpoint)
         return resp["data"]
 
-    def get_metadata(self, connector_id, metadata) -> dict:
+    def get_metadata(self, connector_id: str, metadata: str) -> dict[str, Any]:
         """
         Fetches metadata for a given metadata string and connector.
 
@@ -215,11 +231,8 @@ class FivetranHook(BaseHook):
 
         :param connector_id: Fivetran connector_id, found in connector settings
             page in the Fivetran user interface.
-        :type connector_id: str
         :param metadata: The string to return the type of metadata from the API
-        :type metadata: str
         :return: table or column metadata details
-        :rtype: Dict
         """
         metadata_values = ("tables", "columns")
         if connector_id == "":
@@ -227,45 +240,42 @@ class FivetranHook(BaseHook):
         if metadata not in metadata_values:
             raise ValueError(f"Got {metadata} for param 'metadata', expected one" f" of: {metadata_values}")
         endpoint = self.api_metadata_path_connectors + connector_id + "/" + metadata
-        resp = self._do_api_call(("GET", endpoint))
+        resp = self._do_api_call("GET", endpoint)
         return resp["data"]
 
-    def get_destinations(self, group_id) -> dict:
+    def get_destinations(self, group_id: str) -> dict:
         """
         Fetches destination information for the given group.
         :param group_id: The Fivetran group ID, returned by a connector API call.
-        :type group_id: str
         :return: destination details
         :rtype: Dict
         """
         if group_id == "":
             raise ValueError("No value specified for group_id")
         endpoint = self.api_path_destinations + group_id
-        resp = self._do_api_call(("GET", endpoint))
+        resp = self._do_api_call("GET", endpoint)
         return resp["data"]
 
-    def get_groups(self, group_id) -> dict:
+    def get_groups(self, group_id: str) -> dict:
         """
         Fetches destination information for the given group.
         :param group_id: The Fivetran group ID, returned by a connector API call.
-        :type group_id: str
         :return: group details
-        :rtype: Dict
         """
         if group_id == "":
             raise ValueError("No value specified for connector_id")
         endpoint = self.api_path_groups + group_id
-        resp = self._do_api_call(("GET", endpoint))
+        resp = self._do_api_call("GET", endpoint)
         return resp["data"]
 
-    def check_connector(self, connector_id):
+    def check_connector(self, connector_id: str) -> dict[str, Any]:
         """
         Ensures connector configuration has been completed successfully and is in
             a functional state.
 
         :param connector_id: Fivetran connector_id, found in connector settings
             page in the Fivetran user interface.
-        :type connector_id: str
+        :return: API call response
         """
         connector_details = self.get_connector(connector_id)
         service_name = connector_details["service"]
@@ -279,57 +289,53 @@ class FivetranHook(BaseHook):
             )
         self.log.info("Connector type: %s, connector schema: %s", service_name, schema_name)
         self.log.info("Connectors logs at %s", self._connector_ui_url_logs(service_name, schema_name))
-        return True
+        return connector_details
 
-    def set_schedule_type(self, connector_id, schedule_type):
+    def set_schedule_type(self, connector_id: str, schedule_type: str) -> dict[str, Any]:
         """
         Set connector sync mode to switch sync control between API and UI.
 
         :param connector_id: Fivetran connector_id, found in connector settings
             page in the Fivetran user interface.
-        :type connector_id: str
         :param schedule_type: "manual" (schedule controlled via Airlow) or
             "auto" (schedule controlled via Fivetran)
-        :type schedule_type: str
+        :return: API call response
         """
         endpoint = self.api_path_connectors + connector_id
-        return self._do_api_call(("PATCH", endpoint), json.dumps({"schedule_type": schedule_type}))
+        return self._do_api_call("PATCH", endpoint, json={"schedule_type": schedule_type})
 
-    def prep_connector(self, connector_id, schedule_type):
+    def prep_connector(self, connector_id: str, schedule_type: str) -> None:
         """
         Prepare the connector to run in Airflow by checking that it exists and is a good state,
             then update connector sync schedule type if changed.
 
         :param connector_id: Fivetran connector_id, found in connector settings
             page in the Fivetran user interface.
-        :type connector_id: str
         :param schedule_type: Fivetran connector schedule type
-        :type schedule_type: str
         """
-        self.check_connector(connector_id)
+        connector_details = self.check_connector(connector_id)
         if schedule_type not in {"manual", "auto"}:
             raise ValueError('schedule_type must be either "manual" or "auto"')
-        if self.get_connector(connector_id)["schedule_type"] != schedule_type:
-            return self.set_schedule_type(connector_id, schedule_type)
-        return True
+        if connector_details["schedule_type"] != schedule_type:
+            self.set_schedule_type(connector_id, schedule_type)
+        else:
+            self.log.debug("Schedule type for %s was already %s", connector_id, schedule_type)
 
-    def start_fivetran_sync(self, connector_id):
+    def start_fivetran_sync(self, connector_id: str) -> str:
         """
         :param connector_id: Fivetran connector_id, found in connector settings
             page in the Fivetran user interface.
-        :type connector_id: str
         :return: Timestamp of previously completed sync
-        :rtype: str
         """
         connector_details = self.get_connector(connector_id)
         succeeded_at = connector_details["succeeded_at"]
         failed_at = connector_details["failed_at"]
         endpoint = self.api_path_connectors + connector_id
-        if self._do_api_call(("GET", endpoint))["data"]["paused"] is True:
-            self._do_api_call(("PATCH", endpoint), json.dumps({"paused": False}))
+        if self._do_api_call("GET", endpoint)["data"]["paused"] is True:
+            self._do_api_call("PATCH", endpoint, json={"paused": False})
             if succeeded_at is None and failed_at is None:
                 succeeded_at = str(pendulum.now())
-        self._do_api_call(("POST", endpoint + "/force"))
+        self._do_api_call("POST", endpoint + "/force")
 
         failed_at_time = None
         try:
@@ -345,16 +351,14 @@ class FivetranHook(BaseHook):
         )
         return last_sync
 
-    def get_last_sync(self, connector_id, xcom=""):
+    def get_last_sync(self, connector_id: str, xcom: str = "") -> pendulum.DateTime:
         """
         Get the last time Fivetran connector completed a sync.
             Used with FivetranSensor to monitor sync completion status.
 
         :param connector_id: Fivetran connector_id, found in connector settings
             page in the Fivetran user interface.
-        :type connector_id: str
         :param xcom: Timestamp as string pull from FivetranOperator via XCOM
-        :type xcom: str
         :return: Timestamp of last completed sync
         :rtype: Pendulum.DateTime
         """
@@ -367,19 +371,18 @@ class FivetranHook(BaseHook):
             last_sync = succeeded_at if succeeded_at > failed_at else failed_at
         return last_sync
 
-    def get_sync_status(self, connector_id, previous_completed_at, reschedule_time=0):
+    def get_sync_status(
+        self, connector_id: str, previous_completed_at: pendulum.DateTime, reschedule_time: int = 0
+    ) -> bool:
         """
         For sensor, return True if connector's 'succeeded_at' field has updated.
 
         :param connector_id: Fivetran connector_id, found in connector settings
             page in the Fivetran user interface.
-        :type connector_id: str
         :param previous_completed_at: The last time the connector ran, collected on Sensor
             initialization.
-        :type previous_completed_at: pendulum.datetime.DateTime
         :param reschedule_time: Optional, if connector is in reset state
             number of seconds to wait before restarting, else Fivetran suggestion used
-        :type reschedule_time: int
         """
         # @todo Need logic here to tell if the sync is not running at all and not
         # likely to run in the near future.
@@ -419,7 +422,7 @@ class FivetranHook(BaseHook):
         else:
             return False
 
-    def pause_and_restart(self, connector_id, reschedule_for, reschedule_time):
+    def pause_and_restart(self, connector_id: str, reschedule_for: str, reschedule_time: int) -> str:
         """
         While a connector is syncing, if it falls into a reschedule state,
         wait for a time either specified by the user of recommended by Fivetran,
@@ -427,13 +430,10 @@ class FivetranHook(BaseHook):
 
         :param connector_id: Fivetran connector_id, found in connector settings
             page in the Fivetran user interface.
-        :type connector_id: str
         :param reschedule_for: From connector details, if schedule_type is manual,
             then the connector expects triggering the event at the designated UTC time
-        :type reschedule_for: str
         :param reschedule_time: Optional, if connector is in reset state
             number of seconds to wait before restarting, else Fivetran suggestion used
-        :type reschedule_time: int
         """
         if reschedule_time:
             self.log.info("Starting connector again in %s seconds", reschedule_time)
@@ -495,41 +495,47 @@ class FivetranHookAsync(FivetranHook):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-    async def _do_api_call_async(self, endpoint_info, json=None, headers=None):
-        method, endpoint = endpoint_info
+    def _prepare_api_call_kwargs(self, method: str, endpoint: str, **kwargs: Any) -> dict[str, Any]:
+        kwargs = super()._prepare_api_call_kwargs(method, endpoint, **kwargs)
+        auth = kwargs.get("auth")
+        if auth is not None and is_container(auth) and 2 <= len(auth) <= 3:
+            kwargs["auth"] = aiohttp.BasicAuth(*auth)
+        return kwargs
 
-        if not self.fivetran_conn:
+    async def _do_api_call_async(
+        self, method: str, endpoint: str = None, **kwargs: Any  # type: ignore[assignment]
+    ) -> dict[str, Any]:
+        # Check for previous implementation:
+        if is_container(method) and len(method) == 2:
+            import warnings
+
+            warnings.warn(
+                "The API for _do_api_call_async() has changed to closer match the"
+                " aiohttp.ClientSession.request() API. Please update your code accordingly.",
+                AirflowProviderDeprecationWarning,
+                stacklevel=2,
+            )
+            method, endpoint = method  # type: ignore[misc]
+        elif endpoint is None:
+            raise TypeError(
+                f"{self.__class__.__name__}._do_api_call_async() missing 1 required"
+                f" positional argument: 'endpoint'"
+            )
+
+        if self.fivetran_conn is None:
             self.fivetran_conn = await sync_to_async(self.get_connection)(self.conn_id)
-        auth = (self.fivetran_conn.login, self.fivetran_conn.password)
+
         url = f"{self.api_protocol}://{self.api_host}/{endpoint}"
-        if headers is None:
-            headers = {}
-        headers.update({"User-Agent": self.api_user_agent})
+
+        kwargs = self._prepare_api_call_kwargs(method, endpoint, **kwargs)
 
         async with aiohttp.ClientSession() as session:
-            if method == "GET":
-                request_func = session.get
-            elif method == "POST":
-                request_func = session.post
-                headers.update({"Content-Type": "application/json;version=2"})
-            elif method == "PATCH":
-                request_func = session.patch
-                headers.update({"Content-Type": "application/json;version=2"})
-            else:
-                raise AirflowException("Unexpected HTTP Method: " + method)
-
             attempt_num = 1
             while True:
                 try:
-                    response = await request_func(
-                        url,
-                        data=json if method in ("POST", "PATCH") else None,
-                        params=json if method == "GET" else None,
-                        auth=aiohttp.BasicAuth(login=auth[0], password=auth[1]),
-                        headers=headers,
-                    )
+                    response = await session.request(method, url, **kwargs)
                     response.raise_for_status()
-                    return cast(Dict[str, Any], await response.json())
+                    return await response.json()
                 except ClientResponseError as e:
                     if not _retryable_error_async(e):
                         # In this case, the user probably made a mistake.
@@ -558,11 +564,13 @@ class FivetranHookAsync(FivetranHook):
             raise ValueError("No value specified for connector_id")
         endpoint = self.api_path_connectors + connector_id
         resp = await self._do_api_call_async(
-            ("GET", endpoint), headers={"Accept": "application/json;version=2"}
+            "GET", endpoint, headers={"Accept": "application/json;version=2"}
         )
         return resp["data"]
 
-    async def get_sync_status_async(self, connector_id, previous_completed_at, reschedule_wait_time=0):
+    async def get_sync_status_async(
+        self, connector_id: str, previous_completed_at: pendulum.DateTime, reschedule_wait_time: int = 0
+    ):
         """
         For sensor, return True if connector's 'succeeded_at' field has updated.
 
@@ -617,7 +625,7 @@ class FivetranHookAsync(FivetranHook):
             job_status = "pending"
             return job_status
 
-    def pause_and_restart(self, connector_id, reschedule_for, reschedule_wait_time):
+    def pause_and_restart(self, connector_id: str, reschedule_for: str, reschedule_wait_time: int = 0) -> str:
         """
         While a connector is syncing, if it falls into a reschedule state,
         wait for a time either specified by the user of recommended by Fivetran,
@@ -653,17 +661,20 @@ class FivetranHookAsync(FivetranHook):
         self.log.info("Restarting connector now")
         return self.start_fivetran_sync(connector_id)
 
-    def _parse_timestamp(self, api_time):
+    def _parse_timestamp(self, api_time: datetime | str | None) -> pendulum.DateTime:
         """
         Returns either the pendulum-parsed actual timestamp or a very out-of-date timestamp if not set.
 
         :param api_time: timestamp format as returned by the Fivetran API.
-        :type api_time: str
-        :rtype: Pendulum.DateTime
         """
-        return pendulum.parse(api_time) if api_time is not None else pendulum.from_timestamp(-1)
+        if isinstance(api_time, datetime):
+            return pendulum.instance(api_time)
+        elif isinstance(api_time, str):
+            return pendulum.parse(api_time)  # type: ignore[return-value]
+        else:
+            return pendulum.from_timestamp(-1)
 
-    async def get_last_sync_async(self, connector_id, xcom=""):
+    async def get_last_sync_async(self, connector_id: str, xcom: str = "") -> pendulum.DateTime:
         """
         Get the last time Fivetran connector completed a sync.
         Used with FivetranSensorAsync to monitor sync completion status.
@@ -691,12 +702,11 @@ def _retryable_error_async(exception: ClientResponseError) -> bool:
     return exception.status >= 500
 
 
-def _retryable_error(exception) -> bool:
-    return (
-        isinstance(
-            exception,
-            (requests_exceptions.ConnectionError, requests_exceptions.Timeout),
-        )
-        or exception.response is not None
-        and exception.response.status_code >= 500
+def _retryable_error(exception: Exception) -> bool:
+    return isinstance(
+        exception,
+        (requests_exceptions.ConnectionError, requests_exceptions.Timeout),
+    ) or (
+        getattr(exception, "response", None) is not None
+        and getattr(exception, "response").status_code >= 500  # noqa: B009
     )

--- a/fivetran_provider_async/hooks.py
+++ b/fivetran_provider_async/hooks.py
@@ -10,7 +10,7 @@ import aiohttp
 import pendulum
 import requests
 from aiohttp import ClientResponseError
-from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
+from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
 from airflow.utils.helpers import is_container
 from asgiref.sync import sync_to_async
@@ -69,7 +69,7 @@ class FivetranHook(BaseHook):
         """
         Fetch and return the current Airflow version
         from aws provider
-        https://github.com/apache/airflow/blob/main/airflow/providers/amazon/aws/hooks/base_aws.py#L536
+        https://github.com/apache/airflow/blob/ae25a52ae342c9e0bc3afdb21d613447c3687f6c/airflow/providers/amazon/aws/hooks/base_aws.py#L536
         """
         try:
             # This can be a circular import under specific configurations.
@@ -134,7 +134,7 @@ class FivetranHook(BaseHook):
             warnings.warn(
                 "The API for _do_api_call() has changed to closer match the"
                 " requests.request() API. Please update your code accordingly.",
-                AirflowProviderDeprecationWarning,
+                DeprecationWarning,
                 stacklevel=2,
             )
             method, endpoint = method  # type: ignore[misc]
@@ -512,7 +512,7 @@ class FivetranHookAsync(FivetranHook):
             warnings.warn(
                 "The API for _do_api_call_async() has changed to closer match the"
                 " aiohttp.ClientSession.request() API. Please update your code accordingly.",
-                AirflowProviderDeprecationWarning,
+                DeprecationWarning,
                 stacklevel=2,
             )
             method, endpoint = method  # type: ignore[misc]

--- a/fivetran_provider_async/hooks.py
+++ b/fivetran_provider_async/hooks.py
@@ -92,13 +92,15 @@ class FivetranHook(BaseHook):
         self.retry_limit = retry_limit
         self.retry_delay = retry_delay
 
-    def _do_api_call(self, endpoint_info, json=None):
+    def _do_api_call(self, endpoint_info, json=None, headers=None):
         """
         Utility function to perform an API call with retries
 
         :param endpoint_info: Tuple of method and endpoint
         :type endpoint_info: tuple[string, string]
         :param json: Parameters for this API call.
+        :type json: dict
+        :param json: Headers for this API call.
         :type json: dict
         :return: If the api call returns a OK status code,
             this function returns the response in JSON. Otherwise,
@@ -111,7 +113,9 @@ class FivetranHook(BaseHook):
         auth = (self.fivetran_conn.login, self.fivetran_conn.password)
         url = f"{self.api_protocol}://{self.api_host}/{endpoint}"
 
-        headers = {"User-Agent": self.api_user_agent + self._get_airflow_version()}
+        if headers is None:
+            headers = {}
+        headers.update({"User-Agent": self.api_user_agent + self._get_airflow_version()})
 
         if method == "GET":
             request_func = requests.get
@@ -491,14 +495,16 @@ class FivetranHookAsync(FivetranHook):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-    async def _do_api_call_async(self, endpoint_info, json=None):
+    async def _do_api_call_async(self, endpoint_info, json=None, headers=None):
         method, endpoint = endpoint_info
 
         if not self.fivetran_conn:
             self.fivetran_conn = await sync_to_async(self.get_connection)(self.conn_id)
         auth = (self.fivetran_conn.login, self.fivetran_conn.password)
         url = f"{self.api_protocol}://{self.api_host}/{endpoint}"
-        headers = {"User-Agent": self.api_user_agent}
+        if headers is None:
+            headers = {}
+        headers.update({"User-Agent": self.api_user_agent})
 
         async with aiohttp.ClientSession() as session:
             if method == "GET":
@@ -551,7 +557,9 @@ class FivetranHookAsync(FivetranHook):
         if connector_id == "":
             raise ValueError("No value specified for connector_id")
         endpoint = self.api_path_connectors + connector_id
-        resp = await self._do_api_call_async(("GET", endpoint))
+        resp = await self._do_api_call_async(
+            ("GET", endpoint), headers={"Accept": "application/json;version=2"}
+        )
         return resp["data"]
 
     async def get_sync_status_async(self, connector_id, previous_completed_at, reschedule_wait_time=0):

--- a/fivetran_provider_async/hooks.py
+++ b/fivetran_provider_async/hooks.py
@@ -49,8 +49,8 @@ class FivetranHook(BaseHook):
     api_path_destinations = "v1/destinations/"
     api_path_groups = "v1/groups/"
 
-    @staticmethod
-    def get_ui_field_behaviour() -> Dict:
+    @classmethod
+    def get_ui_field_behaviour(cls) -> Dict:
         """Returns custom field behaviour"""
         return {
             "hidden_fields": ["schema", "port", "extra", "host"],

--- a/fivetran_provider_async/operators.py
+++ b/fivetran_provider_async/operators.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
-from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
+from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator, BaseOperatorLink
 
 if TYPE_CHECKING:
@@ -102,16 +102,6 @@ class FivetranOperator(BaseOperator):
                     method_name="execute_complete",
                 )
             return None
-
-    def _get_hook(self) -> FivetranHook:
-        import warnings
-
-        warnings.warn(
-            "self._get_hook() has been deprecated. Please use `self.hook`",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
-        return self.hook
 
     @cached_property
     def hook(self) -> FivetranHook:
@@ -217,6 +207,6 @@ class FivetranOperatorAsync(FivetranOperator):
 
         warnings.warn(
             "FivetranOperatorAsync has been deprecated. Please use `FivetranOperator`.",
-            AirflowProviderDeprecationWarning,
+            DeprecationWarning,
             stacklevel=2,
         )

--- a/fivetran_provider_async/sensors.py
+++ b/fivetran_provider_async/sensors.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
-from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
+from airflow.exceptions import AirflowException
 from airflow.sensors.base import BaseSensorOperator
 
 if TYPE_CHECKING:
@@ -95,16 +95,6 @@ class FivetranSensor(BaseSensorOperator):
                 method_name="execute_complete",
             )
 
-    def _get_hook(self) -> FivetranHook:
-        import warnings
-
-        warnings.warn(
-            "self._get_hook() has been deprecated. Please use `self.hook`",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
-        return self.hook
-
     @cached_property
     def hook(self) -> FivetranHook:
         """Create and return a FivetranHook."""
@@ -148,6 +138,6 @@ class FivetranSensorAsync(FivetranSensor):
 
         warnings.warn(
             "FivetranSensorAsync has been deprecated. Please use `FivetranSensor`.",
-            AirflowProviderDeprecationWarning,
+            DeprecationWarning,
             stacklevel=2,
         )

--- a/fivetran_provider_async/sensors.py
+++ b/fivetran_provider_async/sensors.py
@@ -14,16 +14,25 @@ from fivetran_provider_async.triggers import FivetranTrigger
 
 class FivetranSensor(BaseSensorOperator):
     """
-    `FivetranSensor` asynchronously monitors a Fivetran sync job for completion.
+    `FivetranSensor` asynchronously monitors for a Fivetran sync job to complete
+    after the sensor starts running.
+
     Monitoring with `FivetranSensor` allows you to trigger downstream processes only
     when the Fivetran sync jobs have completed, ensuring data consistency. You can
     use multiple instances of `FivetranSensor` to monitor multiple Fivetran
-    connectors. `FivetranSensor` requires that you specify the `connector_id` of the sync
-    job to start. You can find `connector_id` in the Settings page of the connector you configured in the
-    `Fivetran dashboard <https://fivetran.com/dashboard/connectors>`_.
-    If you do not want to run `FivetranSensor` in async mode you can set `deferrable` to
-    False in sensor.
+    connectors.
 
+    `FivetranSensor` starts monitoring for a new sync to complete starting from
+    the clock time the sensor is triggered. This sensor does not take into
+    account the DagRun's `logical_date` or `data_interval_end`.
+
+    `FivetranSensor` requires that you specify the `connector_id` of the sync
+    job to start. You can find `connector_id` in the Settings page of the
+    connector you configured in the
+    `Fivetran dashboard <https://fivetran.com/dashboard/connectors>`_.
+
+    If you do not want to run `FivetranSensor` in async mode, you can set
+    `deferrable` to False in sensor.
 
     :param fivetran_conn_id: `Conn ID` of the Connection to be used to configure
         the hook.

--- a/fivetran_provider_async/utils/operator_utils.py
+++ b/fivetran_provider_async/utils/operator_utils.py
@@ -23,6 +23,8 @@ def _get_table_id(schemas_api_table_name, schemas_api_table, tables_api_tables, 
     for table_api_table in tables_api_tables["items"]:
         if table_api_table[f"name_in_{loc}"] == schema_api_table_name:
             return table_api_table["id"]
+    else:
+        raise ValueError(f"{schema_api_table_name} not found in tables_api_tables['items']")
 
 
 def _get_fields(table_id, columns, loc):

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,8 @@ install_requires =
 
 [options.extras_require]
 tests =
+    mypy
+    types-requests
     parameterized
     pytest
     pytest-asyncio

--- a/tests/hooks/test_fivetran.py
+++ b/tests/hooks/test_fivetran.py
@@ -317,7 +317,7 @@ class TestFivetranHookAsync:
         mock_api_call_async_response.return_value = MOCK_FIVETRAN_RESPONSE_PAYLOAD_SHEETS
 
         result = hook.pause_and_restart(
-            connector_id="interchangeable_revenge", reschedule_for="manual", reschedule_wait_time=60
+            connector_id="interchangeable_revenge", reschedule_for="manual", reschedule_wait_time=5
         )
         assert result is True
 
@@ -353,7 +353,7 @@ class TestFivetranHookAsync:
             return {"status": "success"}
 
         mock_session.return_value.__aexit__.return_value = mock_fun
-        mock_session.return_value.__aenter__.return_value.get.return_value.json.return_value = {
+        mock_session.return_value.__aenter__.return_value.request.return_value.json.return_value = {
             "status": "success"
         }
 
@@ -376,7 +376,7 @@ class TestFivetranHookAsync:
             return {"status": "success"}
 
         mock_session.return_value.__aexit__.return_value = mock_fun
-        mock_session.return_value.__aenter__.return_value.patch.return_value.json.return_value = {
+        mock_session.return_value.__aenter__.return_value.request.return_value.json.return_value = {
             "status": "success"
         }
 
@@ -399,7 +399,7 @@ class TestFivetranHookAsync:
             return {"status": "success"}
 
         mock_session.return_value.__aexit__.return_value = mock_fun
-        mock_session.return_value.__aenter__.return_value.post.return_value.json.return_value = {
+        mock_session.return_value.__aenter__.return_value.request.return_value.json.return_value = {
             "status": "success"
         }
 
@@ -414,25 +414,11 @@ class TestFivetranHookAsync:
     @pytest.mark.asyncio
     @mock.patch("fivetran_provider_async.hooks.aiohttp.ClientSession")
     @mock.patch("fivetran_provider_async.hooks.FivetranHookAsync.get_connection")
-    async def test_do_api_call_async_unexpected_method_error(self, mock_get_connection, mock_session):
-        """Tests that _do_api_call_async method raises exception when a wrong request is sent"""
-        hook = FivetranHookAsync(fivetran_conn_id="conn_fivetran")
-
-        hook.fivetran_conn = mock_get_connection
-        hook.fivetran_conn.login = LOGIN
-        hook.fivetran_conn.password = PASSWORD
-        with pytest.raises(AirflowException) as exc:
-            await hook._do_api_call_async(("UNKNOWN", "v1/connectors/test"))
-        assert str(exc.value) == "Unexpected HTTP Method: UNKNOWN"
-
-    @pytest.mark.asyncio
-    @mock.patch("fivetran_provider_async.hooks.aiohttp.ClientSession")
-    @mock.patch("fivetran_provider_async.hooks.FivetranHookAsync.get_connection")
     async def test_do_api_call_async_with_non_retryable_client_response_error(
         self, mock_get_connection, mock_session
     ):
         """Tests that _do_api_call_async method returns expected response for a non retryable error"""
-        mock_session.return_value.__aenter__.return_value.patch.return_value.json.side_effect = (
+        mock_session.return_value.__aenter__.return_value.request.return_value.json.side_effect = (
             ClientResponseError(
                 request_info=RequestInfo(url="example.com", method="PATCH", headers=multidict.CIMultiDict()),
                 status=400,
@@ -457,7 +443,7 @@ class TestFivetranHookAsync:
         self, mock_get_connection, mock_session
     ):
         """Tests that _do_api_call_async method raises exception for a retryable error"""
-        mock_session.return_value.__aenter__.return_value.patch.return_value.json.side_effect = (
+        mock_session.return_value.__aenter__.return_value.request.return_value.json.side_effect = (
             ClientResponseError(
                 request_info=RequestInfo(url="example.com", method="PATCH", headers=multidict.CIMultiDict()),
                 status=500,


### PR DESCRIPTION
Resolves #53

# Changes

## Docstring clarification for `FivetranSensor`

I added this because I thought I was working on #49 when I first started coding.

In any event, I added language clarifying how `FivetranSensor` works more specifically than what was there.

## Type-checking

A lot of `hooks.py` was un-annotated, so I made sure to get the whole thing annotated.

I then added Mypy to the pre-commit. I also added `mypy` to the CI.

## `_do_api_call()` and `_do_api_call_async()` API changes

I made these more plainly wrap the `requests.request()` and `asyncio.ClientSession.request` APIs. It did not seem like there was much reason for these APIs to deviate. Deviations include:

- It had a parameter called `json` that maps to either the `data=json` or `params=json` kwargs in the `requests.request()` call. This seems less desirable than just passing `data=data`, `params=params`, or `json=json`. Specifically, the `json` kwarg is confusing from the perspective of the `requests` and `aiohttp` APIs: in those APIs, `json=` expects a dict and `data=` expects a string, but in the FivetranHook API, `json=` is a string that gets mapped to `data=`.
- The first 2 args were a tuple for method and URL, whereas these could just be args (like `requests.request()`)
- For the internals: it is unnecessarily burdensome from a Mypy perspective, and also inflexible from a future-proofing perspective, to do an if-elif on the method to get the implementation when `requests.request()` can do that for you.

That said, **changing this is probably annoying for users** as there may be many users using this function. So I made sure the old API works and gave a deprecation warning via the following:

```python
if is_container(method) and len(method) == 2:
    import warnings
    warnings.warn(
        "The API for _do_api_call() has changed to closer match the"
        " requests.request() API. Please update your code accordingly.",
        DeprecationWarning,
        stacklevel=2
    )
    method, endpoint = method
elif endpoint is None:
    raise TypeError(
        f"{self.__class__.__name__}._do_api_call() missing 1 required"
        f" positional argument: 'endpoint'"
    )
```

Lastly, I removed the test for `"UNKNOWN"`. The reason why is because `requests.request()` can handle any method passed in, and the Fivetran API itself should be in charge of rejecting bad methods. (Note that this is the only nontrivial test change I made; all other test cases pass with essentially no changes, meaning my code is more or less a refactor.)

**TLDR:**

- `_do_api_call()` now matches `requests.request()`
- I made this backwards compatible with a `DeprecationWarning`

## "Breaking" changes

I put "breaking" in quotes because these are very minor API features that were not being used by anything. That said they still constitute breaking changes, in some sense, if we consider changing the `FivetranHook`'s method return types to constitute breaking changes (even if those return types are not so useful).

- `FivetranHook.check_connector` now returns the `connector_details` dict object. (So that `prep_connector` can avoid making an unnecessary 3rd API call.)
- `FivetranHook.prep_connector` now returns `None` instead of `Literal[True]`.

## Use `hook` as cached property

It is more idiomatic in Airflow code for the `hook` for an operator to be called as a `cached_property`, so I swapped the operator and sensor code to implement this pattern, and added a deprecation warning for `_get_hook()`.