### PR TITLE
Consolidate api for `pause_and_restart` and `_parse_timestamp` methods

### DIFF
--- a/fivetran_provider_async/hooks.py
+++ b/fivetran_provider_async/hooks.py
@@ -376,6 +376,8 @@ class FivetranHook(BaseHook):
         connector_id: str,
         previous_completed_at: pendulum.DateTime,
         reschedule_wait_time: int | None = None,
+        *,
+        reschedule_time: int | None = None,  # deprecated!
     ) -> bool:
         """
         For sensor, return True if connector's 'succeeded_at' field has updated.
@@ -386,7 +388,18 @@ class FivetranHook(BaseHook):
             initialization.
         :param reschedule_wait_time: Optional, if connector is in reset state
             number of seconds to wait before restarting, else Fivetran suggestion used
+        :param reschedule_time: Deprecated
         """
+        if reschedule_time is not None:
+            import warnings
+
+            warnings.warn(
+                "`reschedule_time` arg is deprecated. Please use `reschedule_wait_time` instead.",
+                stacklevel=2,
+            )
+            if reschedule_wait_time is None:
+                reschedule_wait_time = reschedule_time
+
         # @todo Need logic here to tell if the sync is not running at all and not
         # likely to run in the near future.
         connector_details = self.get_connector(connector_id)
@@ -428,7 +441,12 @@ class FivetranHook(BaseHook):
             return False
 
     def pause_and_restart(
-        self, connector_id: str, reschedule_for: str, reschedule_wait_time: int | None = None
+        self,
+        connector_id: str,
+        reschedule_for: str,
+        reschedule_wait_time: int | None = None,
+        *,
+        reschedule_time: int | None = None,  # deprecated!
     ) -> str:
         """
         While a connector is syncing, if it falls into a reschedule state,
@@ -441,7 +459,18 @@ class FivetranHook(BaseHook):
             then the connector expects triggering the event at the designated UTC time
         :param reschedule_wait_time: Optional, if connector is in reset state
             number of seconds to wait before restarting, else Fivetran suggestion used
+        :param reschedule_time: Deprecated
         """
+        if reschedule_time is not None:
+            import warnings
+
+            warnings.warn(
+                "`reschedule_time` arg is deprecated. Please use `reschedule_wait_time` instead.",
+                stacklevel=2,
+            )
+            if reschedule_wait_time is None:
+                reschedule_wait_time = reschedule_time
+
         if reschedule_wait_time is not None:
             self.log.info("Starting connector again in %s seconds", reschedule_wait_time)
             time.sleep(reschedule_wait_time)

--- a/fivetran_provider_async/hooks.py
+++ b/fivetran_provider_async/hooks.py
@@ -460,16 +460,18 @@ class FivetranHook(BaseHook):
         self.log.info("Restarting connector now")
         return self.start_fivetran_sync(connector_id)
 
-    def _parse_timestamp(self, api_time):
+    def _parse_timestamp(self, api_time: datetime | str | None) -> pendulum.DateTime:
         """
-        Returns either the pendulum-parsed actual timestamp or
-            a very out-of-date timestamp if not set
+        Returns either the pendulum-parsed actual timestamp or a very out-of-date timestamp if not set.
 
         :param api_time: timestamp format as returned by the Fivetran API.
-        :type api_time: str
-        :rtype: Pendulum.DateTime
         """
-        return pendulum.parse(api_time) if api_time is not None else pendulum.from_timestamp(-1)
+        if isinstance(api_time, datetime):
+            return pendulum.instance(api_time)
+        elif api_time is None:
+            return pendulum.from_timestamp(-1)
+        else:
+            return pendulum.parse(api_time)  # type: ignore[return-value]
 
     def test_connection(self):
         """
@@ -636,19 +638,6 @@ class FivetranHookAsync(FivetranHook):
         else:
             job_status = "pending"
             return job_status
-
-    def _parse_timestamp(self, api_time: datetime | str | None) -> pendulum.DateTime:
-        """
-        Returns either the pendulum-parsed actual timestamp or a very out-of-date timestamp if not set.
-
-        :param api_time: timestamp format as returned by the Fivetran API.
-        """
-        if isinstance(api_time, datetime):
-            return pendulum.instance(api_time)
-        elif isinstance(api_time, str):
-            return pendulum.parse(api_time)  # type: ignore[return-value]
-        else:
-            return pendulum.from_timestamp(-1)
 
     async def get_last_sync_async(self, connector_id: str, xcom: str = "") -> pendulum.DateTime:
         """

--- a/fivetran_provider_async/hooks.py
+++ b/fivetran_provider_async/hooks.py
@@ -372,7 +372,10 @@ class FivetranHook(BaseHook):
         return last_sync
 
     def get_sync_status(
-        self, connector_id: str, previous_completed_at: pendulum.DateTime, reschedule_time: int = 0
+        self,
+        connector_id: str,
+        previous_completed_at: pendulum.DateTime,
+        reschedule_wait_time: int | None = None,
     ) -> bool:
         """
         For sensor, return True if connector's 'succeeded_at' field has updated.
@@ -381,7 +384,7 @@ class FivetranHook(BaseHook):
             page in the Fivetran user interface.
         :param previous_completed_at: The last time the connector ran, collected on Sensor
             initialization.
-        :param reschedule_time: Optional, if connector is in reset state
+        :param reschedule_wait_time: Optional, if connector is in reset state
             number of seconds to wait before restarting, else Fivetran suggestion used
         """
         # @todo Need logic here to tell if the sync is not running at all and not
@@ -410,7 +413,9 @@ class FivetranHook(BaseHook):
         if sync_state == "rescheduled" and connector_details["schedule_type"] == "manual":
             self.log.info('Connector is in "rescheduled" state and needs to be manually restarted')
             self.pause_and_restart(
-                connector_id, connector_details["status"]["rescheduled_for"], reschedule_time
+                connector_id,
+                connector_details["status"]["rescheduled_for"],
+                reschedule_wait_time=reschedule_wait_time,
             )
             return False
 
@@ -422,7 +427,9 @@ class FivetranHook(BaseHook):
         else:
             return False
 
-    def pause_and_restart(self, connector_id: str, reschedule_for: str, reschedule_time: int) -> str:
+    def pause_and_restart(
+        self, connector_id: str, reschedule_for: str, reschedule_wait_time: int | None = None
+    ) -> str:
         """
         While a connector is syncing, if it falls into a reschedule state,
         wait for a time either specified by the user of recommended by Fivetran,
@@ -432,16 +439,21 @@ class FivetranHook(BaseHook):
             page in the Fivetran user interface.
         :param reschedule_for: From connector details, if schedule_type is manual,
             then the connector expects triggering the event at the designated UTC time
-        :param reschedule_time: Optional, if connector is in reset state
+        :param reschedule_wait_time: Optional, if connector is in reset state
             number of seconds to wait before restarting, else Fivetran suggestion used
         """
-        if reschedule_time:
-            self.log.info("Starting connector again in %s seconds", reschedule_time)
-            time.sleep(reschedule_time)
+        if reschedule_wait_time is not None:
+            self.log.info("Starting connector again in %s seconds", reschedule_wait_time)
+            time.sleep(reschedule_wait_time)
         else:
             wait_time = (
                 self._parse_timestamp(reschedule_for).add(minutes=1) - pendulum.now(tz="UTC")
             ).seconds
+            if wait_time < 0:
+                raise ValueError(
+                    f"Reschedule time {wait_time} configured in "
+                    f"Fivetran connector has elapsed. Sync connector manually."
+                )
             self.log.info("Starting connector again in %s seconds", wait_time)
             time.sleep(wait_time)
 
@@ -569,20 +581,20 @@ class FivetranHookAsync(FivetranHook):
         return resp["data"]
 
     async def get_sync_status_async(
-        self, connector_id: str, previous_completed_at: pendulum.DateTime, reschedule_wait_time: int = 0
+        self,
+        connector_id: str,
+        previous_completed_at: pendulum.DateTime,
+        reschedule_wait_time: int | None = None,
     ):
         """
         For sensor, return True if connector's 'succeeded_at' field has updated.
 
         :param connector_id: Fivetran connector_id, found in connector settings
             page in the Fivetran user interface.
-        :type connector_id: str
         :param previous_completed_at: The last time the connector ran, collected on Sensor
             initialization.
-        :type previous_completed_at: pendulum.datetime.DateTime
         :param reschedule_wait_time: Optional, if connector is in reset state,
             number of seconds to wait before restarting the sync.
-        :type reschedule_wait_time: int
         """
         connector_details = await self.get_connector_async(connector_id)
         succeeded_at = self._parse_timestamp(connector_details["succeeded_at"])
@@ -624,42 +636,6 @@ class FivetranHookAsync(FivetranHook):
         else:
             job_status = "pending"
             return job_status
-
-    def pause_and_restart(self, connector_id: str, reschedule_for: str, reschedule_wait_time: int = 0) -> str:
-        """
-        While a connector is syncing, if it falls into a reschedule state,
-        wait for a time either specified by the user of recommended by Fivetran,
-        Then restart a sync
-
-        :param connector_id: Fivetran connector_id, found in connector settings
-            page in the Fivetran user interface.
-        :type connector_id: str
-        :param reschedule_for: From Fivetran API response, if schedule_type is manual,
-            then the connector expects triggering the event at the designated UTC time.
-        :type reschedule_for: str
-        :param reschedule_wait_time: Optional, if connector is in reset state,
-            number of seconds to wait before restarting the sync.
-        :type reschedule_wait_time: int
-        """
-        if reschedule_wait_time:
-            log_statement = f'Starting connector again in "{reschedule_wait_time}" seconds'
-            self.log.info(log_statement)
-            time.sleep(reschedule_wait_time)
-        else:
-            wait_time = (
-                self._parse_timestamp(reschedule_for).add(minutes=1) - pendulum.now(tz="UTC")
-            ).seconds
-            if wait_time < 0:
-                raise ValueError(
-                    f"Reschedule time {wait_time} configured in "
-                    f"Fivetran connector has elapsed. Sync connector manually."
-                )
-            log_statement = f'Starting connector again in "{wait_time}" seconds'
-            self.log.info(log_statement)
-            time.sleep(wait_time)
-
-        self.log.info("Restarting connector now")
-        return self.start_fivetran_sync(connector_id)
 
     def _parse_timestamp(self, api_time: datetime | str | None) -> pendulum.DateTime:
         """

--- a/fivetran_provider_async/triggers.py
+++ b/fivetran_provider_async/triggers.py
@@ -33,7 +33,7 @@ class FivetranTrigger(BaseTrigger):
         previous_completed_at: pendulum.DateTime | None = None,
         xcom: str = "",
         poke_interval: float = 4.0,
-        reschedule_wait_time: int = 0,
+        reschedule_wait_time: int | None = None,
     ):
         super().__init__()
         self.task_id = task_id

--- a/tests/hooks/test_fivetran.py
+++ b/tests/hooks/test_fivetran.py
@@ -242,7 +242,7 @@ class TestFivetranHookAsync:
         expected_result,
     ):
         """Tests that get_sync_status_async method return success or pending depending on whether
-        current_completed_at > previous_completed_at with reschedule_time specified by user and
+        current_completed_at > previous_completed_at with reschedule_wait_time specified by user and
         schedule_type as manual in API response."""
         mock_start_fivetran_sync.return_value = pendulum.datetime(2021, 3, 21, 21, 55)
         hook = FivetranHookAsync(fivetran_conn_id="conn_fivetran")

--- a/tests/triggers/test_fivetran.py
+++ b/tests/triggers/test_fivetran.py
@@ -68,7 +68,7 @@ def test_fivetran_trigger_serialization():
         "previous_completed_at": PREV_COMPLETED_AT,
         "xcom": "",
         "task_id": "fivetran_sync_task",
-        "reschedule_wait_time": 0,
+        "reschedule_wait_time": None,
     }
 
 


### PR DESCRIPTION
Sorry, one more change before I work on the main PR I want to work on...

## Problem

`pause_and_restart` are defined in the hooks two times (once in async, once in sync), and their APIs are nearly identical. These APIs should be consolidated.

Also `_parse_timestamp` was also not consolidated. (I believe this is my fault from my last PR, my mistake!)

## Details

### Deciding which API to use for `pause_and_restart`

Looking into it a bit, I found this discussion from June:

https://github.com/astronomer/airflow-provider-fivetran-async/pull/25/files/3da1970ad5dd5d8b3babd658ae78cbf09f4373a9

Where a few things were noted:

- `reschedule_wait_time` is a better name than `reschedule_time` (I agree)
- The `raise ValueError` was called when something odd goes wrong.

I also noted that `reschedule_time` is in the `FivetranSensor` class, but so is `reschedule_wait_time`, even though they are the same thing. So, for that reason, I remove `reschedule_time` and add a deprecation warning for people using it.

### Making `reschedule_wait_time` truly optional

I made it so `reschedule_wait_time=None` is a valid input and `sleep(0)`'s instead of being treated as falsy. Instead, `None` is used to implement default behavior. I felt this was appropriate for a couple reasons:

- Docstring describes it as "optional." So this makes it truly optional.
- `sleep(0)` seems like it should be a perfectly valid and supported behavior.

## Minor breakages

- For users using the sync hook directly to call either `get_sync_status` or `call_and_restart`, they will experience breakage if they are using `reschedule_time=`
- For users who manually set `=0`, they will also experience breakage.