### PR TITLE
API Changes to FivetranSensor for supporting backfills

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,31 +33,71 @@ The sensor assumes the `Conn Id` is set to `fivetran`, however if you are managi
 
 ### [Fivetran Operator Async](https://github.com/astronomer/airflow-provider-fivetran-async/tree/main/fivetran_provider_async/operators.py)
 
-`FivetranOperator` submits a Fivetran sync job and monitors it on trigger for completion.
-It requires that you specify the `connector_id` of the sync job to start. You can find `connector_id` in the Settings page of the connector you configured in the [Fivetran dashboard](https://fivetran.com/dashboard/connectors).
-
-Import into your DAG via:
 ```python
 from fivetran_provider_async.operators import FivetranOperator
 ```
 
+`FivetranOperator` submits a Fivetran sync job and monitors it on trigger for completion.
+
+`FivetranOperator` requires that you specify the `connector_id` of the Fivetran connector you wish to trigger. You can find `connector_id` in the Settings page of the connector you configured in the [Fivetran dashboard](https://fivetran.com/dashboard/connectors).
+
+The `FivetranOperator` will wait for the sync to complete so long as `wait_for_completion=True` (this is the default). It is recommended that
+you run in deferrable mode (this is also the default). If `wait_for_completion=False`, the operator will return the timestamp for the last sync.
+
+Import into your DAG via:
+
 ### [Fivetran Sensor Async](https://github.com/astronomer/airflow-provider-fivetran-async/tree/main/fivetran_provider_async/sensors.py)
+
+```python
+from fivetran_provider_async.sensors import FivetranSensor
+```
 
 `FivetranSensor` monitors a Fivetran sync job for completion.
 Monitoring with `FivetranSensor` allows you to trigger downstream processes only when the Fivetran sync jobs have completed, ensuring data consistency.
 
-
+`FivetranSensor` requires that you specify the `connector_id` of the Fivetran connector you want to wait for. You can find `connector_id` in the Settings page of the connector you configured in the [Fivetran dashboard](https://fivetran.com/dashboard/connectors).
 
 You can use multiple instances of `FivetranSensor` to monitor multiple Fivetran connectors.
 
-If used in this way,
+`FivetranSensor` is most commonly useful in two scenarios:
 
-`FivetranSensor` requires that you specify the `connector_id` of the sync job to start. You can find `connector_id` in the Settings page of the connector you configured in the [Fivetran dashboard](https://fivetran.com/dashboard/connectors).
+1. Fivetran is using a separate scheduler than the Airflow scheduler.
+2. You set `wait_for_completion=False` in the `FivetranOperator`, and you need to await the `FivetranOperator` task later. (You may want to do this if you want to arrange your DAG such that some tasks are dependent on _starting_ a sync and other tasks are dependent on _completing_ a sync).
+
+If you are doing the 1st pattern, you may find it useful to set the `completed_after_time` to `data_interval_end`, or `data_interval_end` with some buffer:
+
+```python
+fivetran_sensor = FivetranSensor(
+    task_id="wait_for_fivetran_externally_scheduled_sync",
+    connector_id="bronzing_largely",
+    poke_interval=5,
+    completed_after_time="{{ data_interval_end + macros.timedelta(minutes=1) }}",
+)
+```
+
+If you are doing the 2nd pattern, you can use XComs to pass the target completed time to the sensor:
+
+```python
+fivetran_op = FivetranOperator(
+    task_id="fivetran_sync_my_db",
+    connector_id="bronzing_largely",
+    wait_for_completion=False,
+)
+
+fivetran_sensor = FivetranSensor(
+    task_id="wait_for_fivetran_db_sync",
+    connector_id="bronzing_largely",
+    poke_interval=5,
+    completed_after_time="{{ task_instance.xcom_pull('fivetran_sync_op', key='return_value') }}",
+)
+
+fivetran_op >> fivetran_sensor
+```
+
+You may also specify the `FivetranSensor` without a `completed_after_time`.
+In this case, the sensor will make note of when the last completed time was, and will wait for a new completed time.
 
 Import into your DAG via:
-```python
-from fivetran_provider_async.sensors import FivetranSensor
-```
 
 ## Examples
 

--- a/fivetran_provider_async/example_dags/example_fivetran.py
+++ b/fivetran_provider_async/example_dags/example_fivetran.py
@@ -3,7 +3,6 @@ from datetime import datetime, timedelta
 from airflow import DAG
 
 from fivetran_provider_async.operators import FivetranOperator
-from fivetran_provider_async.sensors import FivetranSensor
 
 default_args = {
     "owner": "Airflow",
@@ -19,18 +18,8 @@ dag = DAG(
 
 with dag:
     fivetran_sync_start = FivetranOperator(
-        task_id="fivetran-task",
+        task_id="fivetran_task",
         fivetran_conn_id="fivetran_default",
         connector_id="{{ var.value.connector_id }}",
         deferrable=False,
     )
-
-    fivetran_sync_wait = FivetranSensor(
-        task_id="fivetran-sensor",
-        fivetran_conn_id="fivetran_default",
-        connector_id="{{ var.value.connector_id }}",
-        poke_interval=5,
-        deferrable=False,
-    )
-
-    fivetran_sync_start >> fivetran_sync_wait

--- a/fivetran_provider_async/example_dags/example_fivetran_async.py
+++ b/fivetran_provider_async/example_dags/example_fivetran_async.py
@@ -34,7 +34,7 @@ with dag:
         task_id="fivetran_async_sensor",
         connector_id="bronzing_largely",
         poke_interval=5,
-        xcom="{{ task_instance.xcom_pull('fivetran_sync_op', key='return_value') }}",
+        completed_after_time="{{ task_instance.xcom_pull('fivetran_sync_op', key='return_value') }}",
     )
 
     fivetran_async_op >> fivetran_sync_op >> fivetran_async_sensor

--- a/fivetran_provider_async/example_dags/example_fivetran_dbt.py
+++ b/fivetran_provider_async/example_dags/example_fivetran_dbt.py
@@ -4,7 +4,6 @@ from airflow import DAG
 from airflow.providers.ssh.operators.ssh import SSHOperator
 
 from fivetran_provider_async.operators import FivetranOperator
-from fivetran_provider_async.sensors import FivetranSensor
 
 default_args = {
     "owner": "Airflow",
@@ -22,21 +21,9 @@ with DAG(
         connector_id="{{ var.value.linkedin_connector_id }}",
     )
 
-    linkedin_sensor = FivetranSensor(
-        task_id="linkedin-sensor",
-        connector_id="{{ var.value.linkedin_connector_id }}",
-        poke_interval=600,
-    )
-
     twitter_sync = FivetranOperator(
         task_id="twitter-ads-sync",
         connector_id="{{ var.value.twitter_connector_id }}",
-    )
-
-    twitter_sensor = FivetranSensor(
-        task_id="twitter-sensor",
-        connector_id="{{ var.value.twitter_connector_id }}",
-        poke_interval=600,
     )
 
     dbt_run = SSHOperator(
@@ -45,6 +32,4 @@ with DAG(
         ssh_conn_id="dbtvm",
     )
 
-    linkedin_sync >> linkedin_sensor
-    twitter_sync >> twitter_sensor
-    [linkedin_sensor, twitter_sensor] >> dbt_run
+    [linkedin_sync, twitter_sync] >> dbt_run

--- a/fivetran_provider_async/example_dags/example_fivetran_xcom.py
+++ b/fivetran_provider_async/example_dags/example_fivetran_xcom.py
@@ -34,7 +34,7 @@ with dag:
         fivetran_conn_id="fivetran_default",
         connector_id="{{ var.value.connector_id }}",
         poke_interval=5,
-        xcom="{{ task_instance.xcom_pull('fivetran-operator', key='return_value') }}",
+        completed_after_time="{{ task_instance.xcom_pull('fivetran-operator', key='return_value') }}",
     )
 
     fivetran_operator >> delay_task >> fivetran_sensor

--- a/fivetran_provider_async/example_dags/example_fivetran_xcom.py
+++ b/fivetran_provider_async/example_dags/example_fivetran_xcom.py
@@ -25,6 +25,7 @@ with dag:
         task_id="fivetran-operator",
         fivetran_conn_id="fivetran_default",
         connector_id="{{ var.value.connector_id }}",
+        wait_for_completion=False,
     )
 
     delay_task = PythonOperator(task_id="delay_python_task", python_callable=lambda: time.sleep(60))

--- a/fivetran_provider_async/hooks.py
+++ b/fivetran_provider_async/hooks.py
@@ -358,11 +358,19 @@ class FivetranHook(BaseHook):
 
         :param connector_id: Fivetran connector_id, found in connector settings
             page in the Fivetran user interface.
-        :param xcom: Timestamp as string pull from FivetranOperator via XCOM
+        :param xcom: Deprecated. Timestamp as string pull from FivetranOperator via XCOM
         :return: Timestamp of last completed sync
         :rtype: Pendulum.DateTime
         """
         if xcom:
+            import warnings
+
+            warnings.warn(
+                "Param `xcom` is deprecated. Timestamps should be rendered in the Operator, Sensor,"
+                " or Triggerer instead",
+                stacklevel=2,
+            )
+
             last_sync = self._parse_timestamp(xcom)
         else:
             connector_details = self.get_connector(connector_id)
@@ -372,56 +380,107 @@ class FivetranHook(BaseHook):
         return last_sync
 
     def get_sync_status(
+        self, connector_id: str, previous_completed_at: pendulum.DateTime, reschedule_time: int | None = None
+    ) -> bool:
+        import warnings
+
+        warnings.warn(
+            "`get_sync_status()` is deprecated. Please use `is_synced_after_target_time()` instead.",
+            stacklevel=2,
+        )
+
+        return self.is_synced_after_target_time(
+            connector_id=connector_id,
+            completed_after_time=previous_completed_at,
+            reschedule_wait_time=reschedule_time,
+            always_wait_when_syncing=False,
+            propagate_failures_forward=False,
+        )
+
+    def is_synced_after_target_time(
         self,
         connector_id: str,
-        previous_completed_at: pendulum.DateTime,
+        completed_after_time: datetime,
         reschedule_wait_time: int | None = None,
-        *,
-        reschedule_time: int | None = None,  # deprecated!
+        always_wait_when_syncing: bool = True,
+        propagate_failures_forward: bool = True,
     ) -> bool:
         """
         For sensor, return True if connector's 'succeeded_at' field has updated.
 
         :param connector_id: Fivetran connector_id, found in connector settings
             page in the Fivetran user interface.
-        :param previous_completed_at: The last time the connector ran, collected on Sensor
-            initialization.
-        :param reschedule_wait_time: Optional, if connector is in reset state
-            number of seconds to wait before restarting, else Fivetran suggestion used
-        :param reschedule_time: Deprecated
+        :param completed_after_time: The time we are comparing the Fivetran
+            `succeeded_at` and `failed_at` timestamps to. The method returns
+            True when both the last `succeeded_at` exceeds the
+            `completed_after_time` and other conditions (determined by other
+            params to this method) are met.
+        :param reschedule_wait_time: Optional. If connector is in a
+            rescheduled state, this will be the number of seconds to wait
+            before restarting. If None, then Fivetran's suggestion is used
+            instead.
+        :param always_wait_when_syncing: If True, then this method will
+            always return False when the connector's sync_state is "syncing",
+            no matter what.
+        :param propagate_failures_forward: If True, then this method will always
+            raise an AirflowException when the most recent connector status is
+            a failure and there are no successes dated after the target time.
+            Specifically, this makes it so that
+            `completed_after_time > failed_at > succeeded_at` is considered a
+            fail condition.
         """
-        if reschedule_time is not None:
-            import warnings
-
-            warnings.warn(
-                "`reschedule_time` arg is deprecated. Please use `reschedule_wait_time` instead.",
-                stacklevel=2,
-            )
-            if reschedule_wait_time is None:
-                reschedule_wait_time = reschedule_time
-
         # @todo Need logic here to tell if the sync is not running at all and not
         # likely to run in the near future.
         connector_details = self.get_connector(connector_id)
+        return self._determine_if_synced_from_connector_details(
+            connector_id=connector_id,
+            connector_details=connector_details,
+            completed_after_time=completed_after_time,
+            reschedule_wait_time=reschedule_wait_time,
+            always_wait_when_syncing=always_wait_when_syncing,
+            propagate_failures_forward=propagate_failures_forward,
+        )
+
+    def _determine_if_synced_from_connector_details(
+        self,
+        connector_id: str,
+        connector_details: dict[str, Any],
+        completed_after_time: datetime,
+        reschedule_wait_time: int | None = None,
+        always_wait_when_syncing: bool = True,
+        propagate_failures_forward: bool = True,
+    ):
         succeeded_at = self._parse_timestamp(connector_details["succeeded_at"])
         failed_at = self._parse_timestamp(connector_details["failed_at"])
-        current_completed_at = succeeded_at if succeeded_at > failed_at else failed_at
-
-        # The only way to tell if a sync failed is to check if its latest
-        # failed_at value is greater than then last known "sync completed at" value.
-        if failed_at > previous_completed_at:
-            service_name = connector_details["service"]
-            schema_name = connector_details["schema"]
-            raise AirflowException(
-                f'Fivetran sync for connector "{connector_id}" failed; '
-                f"please see logs at "
-                f"{self._connector_ui_url_logs(service_name, schema_name)}"
-            )
 
         sync_state = connector_details["status"]["sync_state"]
         self.log.info("Connector %s: sync_state = %s", connector_id, sync_state)
 
-        # if sync in resheduled start, wait for time recommended by Fivetran
+        if always_wait_when_syncing and sync_state == "syncing":
+            return False
+
+        # The only way to tell if a sync failed is to check if its latest
+        # failed_at value is greater than then last known "sync completed at" value.
+        if failed_at > completed_after_time > succeeded_at or (
+            completed_after_time > failed_at > succeeded_at and propagate_failures_forward
+        ):
+            service_name = connector_details["service"]
+            schema_name = connector_details["schema"]
+            raise AirflowException(
+                f"Fivetran sync for connector {connector_id} failed; "
+                f"please see logs at "
+                f"{self._connector_ui_url_logs(service_name, schema_name)}"
+            )
+
+        # Check if sync started by FivetranOperator has finished
+        # indicated by new 'succeeded_at' timestamp
+        if succeeded_at > completed_after_time:
+            self.log.info(
+                "Connector %s: succeeded_at: %s, connector_id", connector_id, succeeded_at.to_iso8601_string()
+            )
+            return True
+
+        # if sync in rescheduled start, wait for time recommended by Fivetran
         # or manually specified, then restart sync
         if sync_state == "rescheduled" and connector_details["schedule_type"] == "manual":
             self.log.info('Connector is in "rescheduled" state and needs to be manually restarted')
@@ -432,13 +491,7 @@ class FivetranHook(BaseHook):
             )
             return False
 
-        # Check if sync started by FivetranOperator has finished
-        # indicated by new 'succeeded_at' timestamp
-        if current_completed_at > previous_completed_at:
-            self.log.info("Connector %s: succeeded_at: %s, connector_id", succeeded_at.to_iso8601_string())
-            return True
-        else:
-            return False
+        return False
 
     def pause_and_restart(
         self,
@@ -616,57 +669,68 @@ class FivetranHookAsync(FivetranHook):
         connector_id: str,
         previous_completed_at: pendulum.DateTime,
         reschedule_wait_time: int | None = None,
-    ):
+    ) -> str:
+        import warnings
+
+        warnings.warn(
+            "`get_sync_status_async()` is deprecated."
+            " Please use `is_synced_after_target_time_async()` instead.",
+            stacklevel=2,
+        )
+
+        return await self.is_synced_after_target_time_async(
+            connector_id=connector_id,
+            completed_after_time=previous_completed_at,
+            reschedule_wait_time=reschedule_wait_time,
+            always_wait_when_syncing=False,
+            propagate_failures_forward=False,
+        )
+
+    async def is_synced_after_target_time_async(
+        self,
+        connector_id: str,
+        completed_after_time: datetime,
+        reschedule_wait_time: int | None = None,
+        always_wait_when_syncing: bool = True,
+        propagate_failures_forward: bool = True,
+    ) -> str:
         """
         For sensor, return True if connector's 'succeeded_at' field has updated.
 
         :param connector_id: Fivetran connector_id, found in connector settings
             page in the Fivetran user interface.
-        :param previous_completed_at: The last time the connector ran, collected on Sensor
-            initialization.
-        :param reschedule_wait_time: Optional, if connector is in reset state,
-            number of seconds to wait before restarting the sync.
+        :param completed_after_time: The time we are comparing the Fivetran
+            `succeeded_at` and `failed_at` timestamps to. The method returns
+            True when both the last `succeeded_at` exceeds the
+            `completed_after_time` and other conditions (determined by other
+            params to this method) are met.
+        :param reschedule_wait_time: Optional. If connector is in a
+            rescheduled state, this will be the number of seconds to wait
+            before restarting. If None, then Fivetran's suggestion is used
+            instead.
+        :param always_wait_when_syncing: If True, then this method will
+            always return False when the connector's sync_state is "syncing",
+            no matter what.
+        :param propagate_failures_forward: If True, then this method will always
+            raise an AirflowException when the most recent connector status is
+            a failure and there are no successes dated after the target time.
+            Specifically, this makes it so that
+            `completed_after_time > failed_at > succeeded_at` is considered a
+            fail condition.
         """
         connector_details = await self.get_connector_async(connector_id)
-        succeeded_at = self._parse_timestamp(connector_details["succeeded_at"])
-        failed_at = self._parse_timestamp(connector_details["failed_at"])
-        current_completed_at = succeeded_at if succeeded_at > failed_at else failed_at
-
-        # The only way to tell if a sync failed is to check if its latest
-        # failed_at value is greater than then last known "sync completed at" value.
-        if failed_at > previous_completed_at:
-            service_name = connector_details["service"]
-            schema_name = connector_details["schema"]
-            raise AirflowException(
-                f"Fivetran sync for connector {connector_id} failed; "
-                f"please see logs at "
-                f"{self._connector_ui_url_logs(service_name, schema_name)}"
-            )
-
-        sync_state = connector_details["status"]["sync_state"]
-        self.log.info('Connector "%s": sync_state = "%s"', connector_id, sync_state)
-
-        # if sync in rescheduled start, wait for time recommended by Fivetran
-        # or manually specified, then restart sync
-        if sync_state == "rescheduled" and connector_details["schedule_type"] == "manual":
-            self.log.info('Connector is in "rescheduled" state and needs to be manually restarted')
-            self.pause_and_restart(
-                connector_id=connector_id,
-                reschedule_for=connector_details["status"]["rescheduled_for"],
-                reschedule_wait_time=reschedule_wait_time,
-            )
-
-        # Check if sync started by airflow has finished
-        # indicated by new 'succeeded_at' timestamp
-        if current_completed_at > previous_completed_at:
-            self.log.info(
-                'Connector "%s": succeeded_at = "%s"', connector_id, succeeded_at.to_iso8601_string()
-            )
-            job_status = "success"
-            return job_status
+        is_completed = self._determine_if_synced_from_connector_details(
+            connector_id=connector_id,
+            connector_details=connector_details,
+            completed_after_time=completed_after_time,
+            reschedule_wait_time=reschedule_wait_time,
+            always_wait_when_syncing=always_wait_when_syncing,
+            propagate_failures_forward=propagate_failures_forward,
+        )
+        if is_completed:
+            return "success"
         else:
-            job_status = "pending"
-            return job_status
+            return "pending"
 
     async def get_last_sync_async(self, connector_id: str, xcom: str = "") -> pendulum.DateTime:
         """

--- a/fivetran_provider_async/hooks.py
+++ b/fivetran_provider_async/hooks.py
@@ -164,8 +164,9 @@ class FivetranHook(BaseHook):
                 if not _retryable_error(e):
                     # In this case, the user probably made a mistake.
                     # Don't retry.
+                    assert e.response is not None  # mypy
                     raise AirflowException(
-                        f"Response: {e.response.content}, " f"Status Code: {e.response.status_code}"
+                        f"Response: {e.response.content!r}, " f"Status Code: {e.response.status_code}"
                     )
 
                 self._log_request_error(attempt_num, str(e))

--- a/fivetran_provider_async/hooks.py
+++ b/fivetran_provider_async/hooks.py
@@ -730,8 +730,7 @@ class FivetranHookAsync(FivetranHook):
         )
         if is_completed:
             return "success"
-        else:
-            return "pending"
+        return "pending"
 
     async def get_last_sync_async(self, connector_id: str, xcom: str = "") -> pendulum.DateTime:
         """

--- a/fivetran_provider_async/hooks.py
+++ b/fivetran_provider_async/hooks.py
@@ -402,7 +402,7 @@ class FivetranHook(BaseHook):
         connector_id: str,
         completed_after_time: datetime,
         reschedule_wait_time: int | None = None,
-        always_wait_when_syncing: bool = True,
+        always_wait_when_syncing: bool = False,
         propagate_failures_forward: bool = True,
     ) -> bool:
         """
@@ -447,7 +447,7 @@ class FivetranHook(BaseHook):
         connector_details: dict[str, Any],
         completed_after_time: datetime,
         reschedule_wait_time: int | None = None,
-        always_wait_when_syncing: bool = True,
+        always_wait_when_syncing: bool = False,
         propagate_failures_forward: bool = True,
     ):
         succeeded_at = self._parse_timestamp(connector_details["succeeded_at"])
@@ -691,7 +691,7 @@ class FivetranHookAsync(FivetranHook):
         connector_id: str,
         completed_after_time: datetime,
         reschedule_wait_time: int | None = None,
-        always_wait_when_syncing: bool = True,
+        always_wait_when_syncing: bool = False,
         propagate_failures_forward: bool = True,
     ) -> str:
         """

--- a/fivetran_provider_async/hooks.py
+++ b/fivetran_provider_async/hooks.py
@@ -450,7 +450,7 @@ class FivetranHook(BaseHook):
         reschedule_wait_time: int | None = None,
         always_wait_when_syncing: bool = False,
         propagate_failures_forward: bool = True,
-    ):
+    ) -> bool:
         succeeded_at = self._parse_timestamp(connector_details["succeeded_at"])
         failed_at = self._parse_timestamp(connector_details["failed_at"])
 

--- a/fivetran_provider_async/operators.py
+++ b/fivetran_provider_async/operators.py
@@ -143,7 +143,7 @@ class FivetranOperator(BaseOperator):
                 self.connector_id, last_sync, propagate_failures_forward=False, always_wait_when_syncing=True
             )
             if is_completed:
-                return None
+                return
             else:
                 self.log.info("sync is still running...")
                 self.log.info("sleeping for %s seconds.", self.poll_frequency)

--- a/fivetran_provider_async/operators.py
+++ b/fivetran_provider_async/operators.py
@@ -50,8 +50,8 @@ class FivetranOperator(BaseOperator):
     :param poll_frequency: Time in seconds that the job should wait in between each try.
     :param reschedule_wait_time: Optional, if connector is in reset state,
             number of seconds to wait before restarting the sync.
-    :param wait_for_completion: Wait for Fivetran sync to complete to finish the task.
     :param deferrable: Run operator in deferrable mode. Default is True.
+    :param wait_for_completion: Wait for Fivetran sync to complete to finish the task.
     """
 
     operator_extra_links = (RegistryLink(),)

--- a/fivetran_provider_async/sensors.py
+++ b/fivetran_provider_async/sensors.py
@@ -86,7 +86,7 @@ class FivetranSensor(BaseSensorOperator):
         fivetran_retry_delay: int = 1,
         completed_after_time: str | datetime | None = None,
         reschedule_wait_time: int | None = None,
-        always_wait_when_syncing: bool = True,
+        always_wait_when_syncing: bool = False,
         propagate_failures_forward: bool = False,
         deferrable: bool = True,
         **kwargs: Any,


### PR DESCRIPTION
Resolves #49

# Changes

### `FivetranOperator`

### High level API:

- **Deprecate `execution_timeout` kwarg.** This isn't even being used. It is pretty straightforward to remove this.
- **(Breaking) Make default behavior when `deferrable=False` to wait for Fivetran sync to complete.**
   - Right now there is a fundamental divergence between how the deferrable and non-deferrable modes work.
   - I would argue that:
      - (1) Typically in Airflow, the `deferrable` param is a parameter that defines the _runtime_ of the operator (i.e. in normal worker nodes vs a triggerer instance), not the fundamental behavior of the operator. For that reason, the `deferrable=?` kwarg should not impact the behavior as dramatically as it currently does.
      - (2) Adding code to make it wait synchronously is not tricky.
      - (3) The existing behavior when `deferrable=False` is significantly worse than waiting, as it leads to the `FivetranSensor` being necessary to await the `FivetranOperator`, whereas the `FivetranSensor` would be more interesting if it were a choice rather than a strict necessity. I updated the `README.md` to clarify what the `FivetranSensor` can/should be used for going forward.
- **Add `wait_for_completion` kwarg.** (I copied this kwarg name from `EcsRunTaskOperator` for whatever that is worth.) This combined with `deferrable` splits what `deferrable` does into two separate options (waiting for Fivetran vs running on Triggerer instance) rather than having them combined into one option.

## `FivetranSensor`

I start by describing the changes to `FivetranOperator` because understanding these changes paves the way to understanding why `FivetranSensor` also changes.

It appears right now that `FivetranSensor` is designed just to await a `FivetranOperator(deferrable=False)`, out of necessity due to lack of functionality when non-deferrable.

However, a much more relevant use case for the `FivetranSensor` is when Fivetran is running on its own schedule, and we want to await a sync scheduled outside of Airflow. The main motivation in designing these API changes is to support that use case. By making `FivetranOperator` always wait by default even when `deferrable=False`, then `FivetranSensor`'s primary purpose can focus on more interesting use cases.

### High level API:

- **Replace `xcom` with `completed_after_time`.** `xcom` is a misleading name. The value does not need to necessarily come from `xcom`. This kwarg was designed originally to be used in the case of `FivetranOperator >> FivetranSensor`, with the intent that the FivetranSensor was always awaiting a manually scheduled job via the completed at time passed through xcom.
   - I originally wanted to name this `target_completed_time` or something similar to emulate the `DateTimeSensor` API. However, this is not a very descriptive name, and it feels especially confusing when using the old `xcom_pull()` pattern (`target_completed_time="{{ task_instance.xcom_pull('fivetran-operator', key='return_value') }}"` looks strange and could be interpreted as "targetting" the last sync value. But in that case it would be unclear why this pattern even works!) I found this name to be a lot clearer.
- **Add `always_wait_when_syncing` kwarg.** So the operator never passes while Fivetran is syncing when this is true.
   - Setting this as a default True won't matter for most users.
   - This is at its most useful for backfills. Fivetran syncs are not atomic and it's possible for table A to be updated while table B is not, or alternatively some rows in table A are written while others are still being written. So running downstream operations while Fivetran is syncing can be a little dangerous, and this operates as an imperfect\* but reasonable check to see if the coast is clear.
- **Added `propagate_failures_forward` kwarg.**
   - This makes it so `target_completed_time > failed_at > succeeded_at` raises an error. By default this is False, matching the existing API.
   - A justification why you may want this to be true is because a `fail > success` indicates an issue that may eventually impact future syncs.

(\* Imperfect because for a long running DAG, or for concurrent task runs, Fivetran can just resync again.)

## `FivetranHook`

### High level API

- **Add `is_synced_after_target_time()` and `is_synced_after_target_time_async()` to replace and `get_sync_status_async()` (which are deprecated).**
   - It was too risky to replace the entire API with something slightly new, so instead I just created a new method name.
   - This name is also a little more descriptive. "get sync status" implies that the value being returned is some sort of enum representing, but in the sync hook implementation it is just a boolean. In reality, it is a mix-- `get_sync_status_async` returns a string but `get_sync_status` returns  boolean. Here the name `is_synced_after_target_time()` implies a boolean return value, which is what you get.
- **Refactor `connector_details` parsing logic so that it is in `_determine_if_synced_from_connector_details()`. This means that both the sync and async operator use the same logic, and it gets to be DRY.
- **Check success before fail in get last sync.** I explain why this is a beneficial change here: https://github.com/astronomer/airflow-provider-fivetran-async/issues/49#issuecomment-1704385524

# Misc.

I did my best to keep the API in tact, which you can see by the fact that there are very few changes in `tests/`.

The main test change I made was so that "succeeded_at > failed_at > completed_after_time" returns a success rather than a failure.