### PR TITLE
Remove deprecated FivetranOperatorAsync and FivetranSensorAsync

### DIFF
--- a/fivetran_provider_async/operators.py
+++ b/fivetran_provider_async/operators.py
@@ -241,18 +241,3 @@ class FivetranOperator(BaseOperator):
 
     def get_openlineage_facets_on_complete(self, task_instance):
         return self.get_openlineage_facets_on_start()
-
-
-class FivetranOperatorAsync(FivetranOperator):
-    """This operator has been deprecated. Please use `FivetranOperator`."""
-
-    def __init__(self, *args, **kwargs):
-        import warnings
-
-        super().__init__(*args, **kwargs)
-
-        warnings.warn(
-            "FivetranOperatorAsync has been deprecated. Please use `FivetranOperator`.",
-            DeprecationWarning,
-            stacklevel=2,
-        )

--- a/fivetran_provider_async/sensors.py
+++ b/fivetran_provider_async/sensors.py
@@ -221,20 +221,3 @@ class FivetranSensor(BaseSensorOperator):
                 self.log.info(
                     event["message"],
                 )
-
-
-class FivetranSensorAsync(FivetranSensor):
-    """This sensor has been deprecated. Please use `FivetranSensor`."""
-
-    template_fields = ["connector_id", "xcom"]
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        import warnings
-
-        super().__init__(*args, **kwargs)
-
-        warnings.warn(
-            "FivetranSensorAsync has been deprecated. Please use `FivetranSensor`.",
-            DeprecationWarning,
-            stacklevel=2,
-        )


### PR DESCRIPTION
since we are planning a major version let's remove FivetranOperatorAsync and FivetranSensorAsync