### PR TITLE
Fix connection form

### DIFF
--- a/fivetran_provider_async/__init__.py
+++ b/fivetran_provider_async/__init__.py
@@ -30,10 +30,6 @@ def get_provider_info():
         "description": "A Fivetran Async provider for Apache Airflow.",
         "connection-types": [
             {
-                "hook-class-name": "fivetran_provider_async.hooks.FivetranHookAsync",
-                "connection-type": "Fivetran",
-            },
-            {
                 "hook-class-name": "fivetran_provider_async.hooks.FivetranHook",
                 "connection-type": "Fivetran",
             },

--- a/fivetran_provider_async/hooks.py
+++ b/fivetran_provider_async/hooks.py
@@ -39,7 +39,7 @@ class FivetranHook(BaseHook):
 
     conn_name_attr = "fivetran_conn_id"
     default_conn_name = "fivetran_default"
-    conn_type = "fivetran"
+    conn_type = "Fivetran"
     hook_name = "Fivetran"
     api_user_agent = "airflow_provider_fivetran/1.1.4"
     api_protocol = "https"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,6 @@ testpaths = [
 [tool.isort]
 profile = "black"
 multi_line_output = 3
+
+[tool.distutils.bdist_wheel]
+universal = true


### PR DESCRIPTION
closes: https://github.com/astronomer/airflow-provider-fivetran-async/issues/60
connection rendering for Fivetran is not coming as intended. This PR will fix it.
**Before**
<img width="1482" alt="Screenshot 2023-12-17 at 5 24 09 PM" src="https://github.com/astronomer/airflow-provider-fivetran-async/assets/98807258/a4c80700-5b11-455f-85e0-d24f1cc34e7b">
**After**
<img width="1459" alt="Screenshot 2023-12-17 at 7 39 19 PM" src="https://github.com/astronomer/airflow-provider-fivetran-async/assets/98807258/d4f110b2-d725-4f2d-8ced-b81ba07f5438">



 