### PR TITLE
Add methods for getting group and connector info

### DIFF
--- a/fivetran_provider_async/hooks.py
+++ b/fivetran_provider_async/hooks.py
@@ -257,15 +257,23 @@ class FivetranHook(BaseHook):
         resp = self._do_api_call("GET", endpoint)
         return resp["data"]
 
-    def get_groups(self, group_id: str) -> dict:
+    def get_groups(self, group_id: str = "") -> dict:
         """
-        Fetches destination information for the given group.
-        :param group_id: The Fivetran group ID, returned by a connector API call.
+        Fetches information about groups.
+        :param group_id: The Fivetran group ID, if provided will restrict to that group.
         :return: group details
         """
-        if group_id == "":
-            raise ValueError("No value specified for connector_id")
         endpoint = self.api_path_groups + group_id
+        resp = self._do_api_call("GET", endpoint)
+        return resp["data"]
+
+    def get_connectors(self, group_id: str) -> dict:
+        """
+        Fetches connector information for the given group.
+        :param group_id: The Fivetran group ID, returned by a connector API call.
+        :return: connector details
+        """
+        endpoint = f"{self.api_path_groups}{group_id}/connectors"
         resp = self._do_api_call("GET", endpoint)
         return resp["data"]
 


### PR DESCRIPTION
Add the ability to get information about all groups without having a group id.  And the ability to list all connectors in that group.  This is needed as without it you need to have the connector and group ids saved somewhere.