### PR TITLE
Set correct default_conn_name in class

### DIFF
--- a/fivetran_provider_async/hooks.py
+++ b/fivetran_provider_async/hooks.py
@@ -84,7 +84,7 @@ class FivetranHook(BaseHook):
 
     def __init__(
         self,
-        fivetran_conn_id: str = "fivetran",
+        fivetran_conn_id: str = "fivetran_default",
         fivetran_conn: Connection | None = None,
         timeout_seconds: int = 180,
         retry_limit: int = 3,

--- a/fivetran_provider_async/operators.py
+++ b/fivetran_provider_async/operators.py
@@ -62,7 +62,7 @@ class FivetranOperator(BaseOperator):
         self,
         connector_id: str,
         run_name: Optional[str] = None,
-        fivetran_conn_id: str = "fivetran",
+        fivetran_conn_id: str = "fivetran_default",
         fivetran_retry_limit: int = 3,
         fivetran_retry_delay: int = 1,
         poll_frequency: int = 15,

--- a/fivetran_provider_async/sensors.py
+++ b/fivetran_provider_async/sensors.py
@@ -80,7 +80,7 @@ class FivetranSensor(BaseSensorOperator):
     def __init__(
         self,
         connector_id: str,
-        fivetran_conn_id: str = "fivetran",
+        fivetran_conn_id: str = "fivetran_default",
         poke_interval: int = 60,
         fivetran_retry_limit: int = 3,
         fivetran_retry_delay: int = 1,

--- a/tests/hooks/test_fivetran.py
+++ b/tests/hooks/test_fivetran.py
@@ -251,10 +251,11 @@ class TestFivetranHookAsync:
     @mock.patch("fivetran_provider_async.hooks.FivetranHookAsync._do_api_call_async")
     async def test_fivetran_hook_get_connector_async(self, mock_api_call_async_response):
         """Tests that the get_connector_async method fetches the details of a connector"""
-        hook = FivetranHookAsync(fivetran_conn_id="conn_fivetran")
+        hook = FivetranHookAsync()
         mock_api_call_async_response.return_value = MOCK_FIVETRAN_RESPONSE_PAYLOAD_SHEETS
         result = await hook.get_connector_async(connector_id="interchangeable_revenge")
         assert result["status"]["setup_state"] == "connected"
+        assert hook.conn_id == hook.default_conn_name
 
     @pytest.mark.asyncio
     @mock.patch("fivetran_provider_async.hooks.FivetranHookAsync._do_api_call_async")

--- a/tests/operators/test_fivetran.py
+++ b/tests/operators/test_fivetran.py
@@ -81,11 +81,9 @@ class TestFivetranOperator(unittest.TestCase):
 
         task = FivetranOperator(
             task_id="fivetran_op_async",
+            fivetran_conn_id="conn_fivetran",
             connector_id="interchangeable_revenge",
         )
-
-        assert task.fivetran_conn_id == FivetranHook.default_conn_name
-
         with pytest.raises(TaskDeferred):
             task.execute(context)
 
@@ -104,11 +102,11 @@ class TestFivetranOperator(unittest.TestCase):
 
         task = FivetranOperator(
             task_id="fivetran_op_async",
-            fivetran_conn_id="conn_fivetran",
             connector_id="interchangeable_revenge",
             reschedule_wait_time=60,
             schedule_type="manual",
         )
+        assert task.fivetran_conn_id == FivetranHook.default_conn_name
         with pytest.raises(TaskDeferred):
             task.execute(context)
 

--- a/tests/operators/test_fivetran.py
+++ b/tests/operators/test_fivetran.py
@@ -6,6 +6,7 @@ import pytest
 import requests_mock
 from airflow.exceptions import AirflowException, TaskDeferred
 
+from fivetran_provider_async.hooks import FivetranHook
 from fivetran_provider_async.operators import FivetranOperator
 from tests.common.static import (
     MOCK_FIVETRAN_DESTINATIONS_RESPONSE_PAYLOAD_SHEETS,
@@ -80,9 +81,11 @@ class TestFivetranOperator(unittest.TestCase):
 
         task = FivetranOperator(
             task_id="fivetran_op_async",
-            fivetran_conn_id="conn_fivetran",
             connector_id="interchangeable_revenge",
         )
+
+        assert task.fivetran_conn_id == FivetranHook.default_conn_name
+
         with pytest.raises(TaskDeferred):
             task.execute(context)
 

--- a/tests/operators/test_fivetran.py
+++ b/tests/operators/test_fivetran.py
@@ -102,11 +102,11 @@ class TestFivetranOperator(unittest.TestCase):
 
         task = FivetranOperator(
             task_id="fivetran_op_async",
+            fivetran_conn_id="conn_fivetran",
             connector_id="interchangeable_revenge",
             reschedule_wait_time=60,
             schedule_type="manual",
         )
-        assert task.fivetran_conn_id == FivetranHook.default_conn_name
         with pytest.raises(TaskDeferred):
             task.execute(context)
 
@@ -186,3 +186,12 @@ class TestFivetranOperator(unittest.TestCase):
         assert schema_field.name == "column_1_dest"
         assert schema_field.type == "VARCHAR(256)"
         assert schema_field.description is None
+
+    def test_default_conn_name(self):
+        task = FivetranOperator(
+            task_id="fivetran_op_async",
+            connector_id="interchangeable_revenge",
+            reschedule_wait_time=60,
+            schedule_type="manual",
+        )
+        assert task.fivetran_conn_id == FivetranHook.default_conn_name

--- a/tests/sensors/test_fivetran.py
+++ b/tests/sensors/test_fivetran.py
@@ -4,6 +4,7 @@ from unittest import mock
 import pytest
 from airflow.exceptions import AirflowException, TaskDeferred
 
+from fivetran_provider_async.hooks import FivetranHook
 from fivetran_provider_async.sensors import FivetranSensor
 from fivetran_provider_async.triggers import FivetranTrigger
 
@@ -63,13 +64,13 @@ class TestFivetranSensor:
         mock_poke.return_value = False
         task = FivetranSensor(
             task_id=TASK_ID,
-            fivetran_conn_id="fivetran_default",
             connector_id="test_connector",
             poke_interval=5,
         )
         with pytest.raises(TaskDeferred) as exc:
             task.execute(context)
         assert isinstance(exc.value.trigger, FivetranTrigger), "Trigger is not a FivetranTrigger"
+        assert task.fivetran_conn_id == FivetranHook.default_conn_name
 
     @mock.patch("fivetran_provider_async.sensors.FivetranSensor.poke")
     def test_fivetran_sensor_async_with_response_wait_time(self, mock_poke):

--- a/tests/triggers/test_fivetran.py
+++ b/tests/triggers/test_fivetran.py
@@ -6,7 +6,6 @@ import pytest
 from airflow.exceptions import AirflowException
 from airflow.triggers.base import TriggerEvent
 
-from fivetran_provider_async.hooks import FivetranHook
 from fivetran_provider_async.triggers import FivetranTrigger
 
 TASK_ID = "fivetran_sync_task"
@@ -113,10 +112,10 @@ async def test_fivetran_trigger_pending(mock_api_call_async_response, mock_get_s
         task_id=TASK_ID,
         poke_interval=POKE_INTERVAL,
         connector_id=CONNECTOR_ID,
+        fivetran_conn_id=FIVETRAN_CONN_ID,
         previous_completed_at=PREV_COMPLETED_AT,
     )
     task = asyncio.create_task(trigger.run().__anext__())
-    assert trigger.fivetran_conn_id == FivetranHook.default_conn_name
     await asyncio.sleep(0.5)
     # TriggerEvent was not returned
     assert task.done() is False

--- a/tests/triggers/test_fivetran.py
+++ b/tests/triggers/test_fivetran.py
@@ -6,6 +6,7 @@ import pytest
 from airflow.exceptions import AirflowException
 from airflow.triggers.base import TriggerEvent
 
+from fivetran_provider_async.hooks import FivetranHook
 from fivetran_provider_async.triggers import FivetranTrigger
 
 TASK_ID = "fivetran_sync_task"
@@ -112,10 +113,10 @@ async def test_fivetran_trigger_pending(mock_api_call_async_response, mock_get_s
         task_id=TASK_ID,
         poke_interval=POKE_INTERVAL,
         connector_id=CONNECTOR_ID,
-        fivetran_conn_id=FIVETRAN_CONN_ID,
         previous_completed_at=PREV_COMPLETED_AT,
     )
     task = asyncio.create_task(trigger.run().__anext__())
+    assert trigger.fivetran_conn_id == FivetranHook.default_conn_name
     await asyncio.sleep(0.5)
     # TriggerEvent was not returned
     assert task.done() is False


### PR DESCRIPTION
The default_conn_name value is `fivetran_default` but class set it to `fivetran` https://github.com/astronomer/airflow-provider-fivetran-async/blob/59b5c2023fddf3fa1e69845d8ea9952727284c4d/fivetran_provider_async/hooks.py#L42