### PR TITLE
Remove old Async operator name from docstring

### DIFF
--- a/fivetran_provider_async/hooks.py
+++ b/fivetran_provider_async/hooks.py
@@ -762,7 +762,7 @@ class FivetranHookAsync(FivetranHook):
     async def get_last_sync_async(self, connector_id: str, xcom: str = "") -> pendulum.DateTime:
         """
         Get the last time Fivetran connector completed a sync.
-        Used with FivetranSensorAsync to monitor sync completion status.
+        Used with FivetranSensor to monitor sync completion status.
 
         :param connector_id: Fivetran connector_id, found in connector settings
             page in the Fivetran user interface.

--- a/fivetran_provider_async/triggers.py
+++ b/fivetran_provider_async/triggers.py
@@ -18,7 +18,7 @@ class FivetranTrigger(BaseTrigger):
     :param fivetran_conn_id: Reference to Fivetran connection id
     :param previous_completed_at: The last time the connector ran, collected on Sensor
         initialization.
-    :param xcom: If used, FivetranSensorAsync receives timestamp of previously
+    :param xcom: If used, FivetranSensor receives timestamp of previously
         completed sync
     :param poke_interval:  polling period in seconds to check for the status
     :param reschedule_wait_time: Optional, if connector is in reset state,

--- a/tests/sensors/test_fivetran.py
+++ b/tests/sensors/test_fivetran.py
@@ -59,7 +59,7 @@ class TestFivetranSensor:
     @mock.patch("fivetran_provider_async.sensors.FivetranSensor.poke")
     def test_fivetran_sensor_async(self, mock_poke):
         """Asserts that a task is deferred and a FivetranTrigger will be fired
-        when the FivetranSensorAsync is executed."""
+        when the FivetranSensor is executed."""
         mock_poke.return_value = False
         task = FivetranSensor(
             task_id=TASK_ID,
@@ -74,7 +74,7 @@ class TestFivetranSensor:
     @mock.patch("fivetran_provider_async.sensors.FivetranSensor.poke")
     def test_fivetran_sensor_async_with_response_wait_time(self, mock_poke):
         """Asserts that a task is deferred and a FivetranTrigger will be fired
-        when the FivetranSensorAsync is executed when reschedule_wait_time is specified."""
+        when the FivetranSensor is executed when reschedule_wait_time is specified."""
         mock_poke.return_value = False
         task = FivetranSensor(
             task_id=TASK_ID,


### PR DESCRIPTION
We removed Async suffix from operators name in 2.0.0 but some docstring still refer this name