### PR TITLE
fix: prepare api call kwargs correctly for synchronous methods when using FivetranHookAsync

### DIFF
--- a/fivetran_provider_async/hooks.py
+++ b/fivetran_provider_async/hooks.py
@@ -634,15 +634,10 @@ class FivetranHookAsync(FivetranHook):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-    def _prepare_api_call_kwargs(self, method: str, endpoint: str, **kwargs: Any) -> dict[str, Any]:
-        # Cache existing auth and remove from kwargs dict.
-        prior_auth = kwargs.pop("auth", None)
-
-        kwargs = super()._prepare_api_call_kwargs(method, endpoint, **kwargs)
+    def _prepare_api_call_kwargs_async(self, method: str, endpoint: str, **kwargs: Any) -> dict[str, Any]:
+        kwargs = self._prepare_api_call_kwargs(method, endpoint, **kwargs)
         auth = kwargs.get("auth")
-        if prior_auth is not None and isinstance(prior_auth, aiohttp.BasicAuth):
-            kwargs["auth"] = prior_auth
-        elif auth is not None and is_container(auth) and 2 <= len(auth) <= 3:
+        if auth is not None and is_container(auth) and 2 <= len(auth) <= 3:
             kwargs["auth"] = aiohttp.BasicAuth(*auth)
         return kwargs
 
@@ -671,7 +666,7 @@ class FivetranHookAsync(FivetranHook):
 
         url = f"{self.api_protocol}://{self.api_host}/{endpoint}"
 
-        kwargs = self._prepare_api_call_kwargs(method, endpoint, **kwargs)
+        kwargs = self._prepare_api_call_kwargs_async(method, endpoint, **kwargs)
 
         async with aiohttp.ClientSession() as session:
             attempt_num = 1

--- a/tests/hooks/test_fivetran.py
+++ b/tests/hooks/test_fivetran.py
@@ -680,7 +680,8 @@ class TestFivetranHookAsync:
     @pytest.mark.asyncio
     @mock.patch("fivetran_provider_async.hooks.FivetranHookAsync.get_connection")
     async def test_prepare_api_call_kwargs_async_returns_aiohttp_basicauth(self, mock_get_connection):
-        """Tests to verify that the 'auth' value returned from kwarg preparation is of type aiohttp.BasicAuth"""
+        """Tests to verify that the 'auth' value returned from kwarg preparation is
+        of type aiohttp.BasicAuth"""
         hook = FivetranHookAsync(fivetran_conn_id="conn_fivetran")
         hook.fivetran_conn = mock_get_connection
         hook.fivetran_conn.login = LOGIN


### PR DESCRIPTION
This is related to issue #107 

Changes:

* Always return `kwargs["auth"]` as a tuple from `FivetranHook._prepare_api_call_kwargs`
* Rename `FivetranHookAsync._prepare_api_call_kwargs` to `FivetranHookAsync._prepare_api_call_kwargs_async`