### PR TITLE
Release 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.1.1 (2024-12-30)
+
+### Bug Fixes
+
+- fix: prepare api call kwargs correctly for synchronous methods when using FivetranHookAsync by @JeremyDOwens in https://github.com/astronomer/airflow-provider-fivetran-async/pull/115
+
+### Others
+
+- Pre-commit hook updates in https://github.com/astronomer/airflow-provider-fivetran-async/pull/104, https://github.com/astronomer/airflow-provider-fivetran-async/pull/105,  https://github.com/astronomer/airflow-provider-fivetran-async/pull/112, https://github.com/astronomer/airflow-provider-fivetran-async/pull/113, https://github.com/astronomer/airflow-provider-fivetran-async/pull/114 and https://github.com/astronomer/airflow-provider-fivetran-async/pull/116
+
 ## 2.1.0 (2024-07-24)
 
 ### Feature

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ifeq (run-mypy,$(firstword $(MAKECMDGOALS)))
   $(eval $(RUN_ARGS):;@:)
 endif
 
-ASTRO_RUNTIME_IMAGE_NAME = "quay.io/astronomer/astro-runtime:8.2.0-base"
+ASTRO_RUNTIME_IMAGE_NAME = "quay.io/astronomer/astro-runtime:12.6.0-base"
 
 dev: ## Create a development Environment using `docker compose` file.
 	IMAGE_NAME=$(ASTRO_RUNTIME_IMAGE_NAME) docker compose -f dev/docker-compose.yaml up -d

--- a/fivetran_provider_async/__init__.py
+++ b/fivetran_provider_async/__init__.py
@@ -1,5 +1,5 @@
 # flake8: noqa F401
-__version__ = "2.1.0"
+__version__ = "2.1.1"
 
 import logging
 


### PR DESCRIPTION
2.1.1 (2024-12-30)
------------------

### Bug Fixes

- fix: prepare api call kwargs correctly for synchronous methods when using FivetranHookAsync by @JeremyDOwens in https://github.com/astronomer/airflow-provider-fivetran-async/pull/115

### Others

- Pre-commit hook updates in https://github.com/astronomer/airflow-provider-fivetran-async/pull/104, https://github.com/astronomer/airflow-provider-fivetran-async/pull/105,  https://github.com/astronomer/airflow-provider-fivetran-async/pull/112, https://github.com/astronomer/airflow-provider-fivetran-async/pull/113, https://github.com/astronomer/airflow-provider-fivetran-async/pull/114 and https://github.com/astronomer/airflow-provider-fivetran-async/pull/116