### PR TITLE
ci: replace flake8 with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,17 +54,3 @@ repos:
       - id: mypy
         additional_dependencies:
           - types-requests
-
-  - repo: https://github.com/pycqa/flake8
-    rev: 7.2.0
-    hooks:
-      - id: flake8
-        args: [--max-line-length=120]
-        additional_dependencies:
-          - flake8-builtins
-          - flake8-comprehensions
-          - flake8-colors
-          - flake8-rst-docstrings
-          - flake8-assertive
-          - flake8-logging-format
-          - flake8-bugbear

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Fivetran Async Provider for Apache Airflow
 
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+
 This package provides an async operator, sensor and hook that integrates [Fivetran](https://fivetran.com) into Apache Airflow.
 `FivetranSensor` allows you to monitor a Fivetran sync job for completion before running downstream processes.
 `FivetranOperator` submits a Fivetran sync job and polls for its status on the triggerer.

--- a/fivetran_provider_async/__init__.py
+++ b/fivetran_provider_async/__init__.py
@@ -1,4 +1,4 @@
-# flake8: noqa F401
+# ruff: noqa F401
 __version__ = "2.1.2"
 
 import logging

--- a/fivetran_provider_async/hooks.py
+++ b/fivetran_provider_async/hooks.py
@@ -167,7 +167,7 @@ class FivetranHook(BaseHook):
                     assert e.response is not None
                     raise AirflowException(
                         f"Response: {e.response.content.decode()}, " f"Status Code: {e.response.status_code}"
-                    )
+                    ) from e
 
                 self._log_request_error(attempt_num, str(e))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ dependencies = [
     "openlineage-airflow>=0.19.2",
 ]
 
-
 [project.optional-dependencies]
 tests = [
     "mypy",
@@ -74,14 +73,11 @@ static-check = " pre-commit run --files fivetran_provider_async/*"
 test = 'sh scripts/test/unit.sh'
 test-cov = 'sh scripts/test/unit-cov.sh'
 
-
 [project.urls]
 Source = "https://github.com/astronomer/airflow-provider-fivetran-async"
 
 [tool.hatch.version]
 path = "fivetran_provider_async/__init__.py"
-
-
 
 [tool.hatch.build]
 sources = ["."]
@@ -99,7 +95,6 @@ universal = true
 filterwarnings = ["ignore::DeprecationWarning"]
 minversion = "6.0"
 
-
 ######################################
 # THIRD PARTY TOOLS
 ######################################
@@ -112,7 +107,16 @@ target-version = ['py39', 'py310', 'py311', 'py312']
 line-length = 120
 
 [tool.ruff.lint]
-select = ["C901", "D300", "I", "F"]
+select = [
+    "A",    # flake8-builtins
+    "B",    # flake8-bugbear
+    "C4",   # flake8-comprehensions
+    "C901",
+    "D300",
+    "I",
+    "F",
+    "G",    # flake8-logging-format
+]
 ignore = ["F541", "C901"]
 
 [tool.ruff.lint.isort]


### PR DESCRIPTION
There's no direct replacement for the following flake8 plugins:

- flake8-colors: Only used for coloring the output.
- flake8-rst-docstrings: We could use [pydocstyle](https://docs.astral.sh/ruff/rules/#pydocstyle-d) instead
- flake8-assertive: We could use [flake8-pytest-style](https://docs.astral.sh/ruff/rules/#flake8-pytest-style-pt) instead
