### PR TITLE
Drop Python 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [{ name = "Astronomer & Fivetran", email = "humans@astronomer.io" }]
 readme = "README.md"
 license = "Apache-2.0"
 license-files = { paths = ["LICENSE"] }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 keywords = ["airflow", "apache-airflow", "provider", "astronomer", "dag"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -22,7 +22,6 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -59,7 +58,7 @@ dependencies = [
 pre-install-commands = ["sh scripts/test/pre-install-airflow.sh {matrix:airflow} {matrix:python}"]
 
 [[tool.hatch.envs.tests.matrix]]
-python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
+python = ["3.9", "3.10", "3.11", "3.12"]
 airflow = ["2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "2.8", "2.9", "2.10"]
 
 [tool.hatch.envs.tests.overrides]


### PR DESCRIPTION
Python 3.8 has officially reached its end-of-life (EOL) as of October 7, 2024. Following this, we should consider dropping support for Python 3.8 in dag-factory to align with best practices for security and compatibility.

### Reasons for Dropping Python 3.8 Support:

#### Python 3.8 EOL:

- As of October 7, 2024, Python 3.8 will no longer receive official security updates or bug fixes.
- Reference: [Python Dev Guide – Version Support](https://devguide.python.org/versions/)

#### Airflow Compatibility:

- Apache Airflow also drops support for Python versions once they reach EOL. Although older versions of Airflow may work with Python 3.8, it poses a risk to security and future compatibility.
- Reference: [Airflow Supported Versions](https://airflow.apache.org/docs/apache-airflow/stable/installation/supported-versions.html#support-for-python-and-kubernetes-versions)

We propose officially dropping support for Python 3.8 in this repo and recommending users to upgrade to Python 3.9 or higher to ensure compatibility and best security practices.