### PR TITLE
Remove Python3.8 ref from unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Build and test
 on:
   push:
-    branches: ['main', 'clean_py3.8_ref']
+    branches: ['main']
   pull_request:
     branches: ['main']
   release:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Build and test
 on:
   push:
-    branches: ['main']
+    branches: ['main', 'clean_py3.8_ref']
   pull_request:
     branches: ['main']
   release:
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
         airflow-version: [ "2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "2.8", "2.9", "2.10" ]
         exclude:
           # Apache Airflow versions prior to 2.3.0 have not been tested with Python 3.10


### PR DESCRIPTION
I forgot to push my local changes to [PR #153](https://github.com/astronomer/airflow-provider-fivetran-async/pull/153), which has caused the CI to break on the main branch.

CI: https://github.com/astronomer/airflow-provider-fivetran-async/actions/runs/15975773387/job/45057725554