### PR TITLE
Add py.typed markers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Typing :: Typed",
 ]
 dependencies = [
     "apache-airflow>=2.2.0",
@@ -52,10 +53,10 @@ tests = [
 ######################################
 
 [tool.hatch.envs.tests]
-dependencies = [
-    "airflow-provider-fivetran-async[tests]",
+dependencies = ["airflow-provider-fivetran-async[tests]"]
+pre-install-commands = [
+    "sh scripts/test/pre-install-airflow.sh {matrix:airflow} {matrix:python}",
 ]
-pre-install-commands = ["sh scripts/test/pre-install-airflow.sh {matrix:airflow} {matrix:python}"]
 
 [[tool.hatch.envs.tests.matrix]]
 python = ["3.9", "3.10", "3.11", "3.12"]
@@ -63,7 +64,9 @@ airflow = ["2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "2.8", "2.9", "2.10"]
 
 [tool.hatch.envs.tests.overrides]
 matrix.airflow.dependencies = [
-    { value = "typing_extensions<4.6", if = ["2.6"] },
+    { value = "typing_extensions<4.6", if = [
+        "2.6",
+    ] },
 ]
 
 [tool.hatch.envs.tests.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,10 +53,10 @@ tests = [
 ######################################
 
 [tool.hatch.envs.tests]
-dependencies = ["airflow-provider-fivetran-async[tests]"]
-pre-install-commands = [
-    "sh scripts/test/pre-install-airflow.sh {matrix:airflow} {matrix:python}",
+dependencies = [
+    "airflow-provider-fivetran-async[tests]",
 ]
+pre-install-commands = ["sh scripts/test/pre-install-airflow.sh {matrix:airflow} {matrix:python}"]
 
 [[tool.hatch.envs.tests.matrix]]
 python = ["3.9", "3.10", "3.11", "3.12"]
@@ -64,9 +64,7 @@ airflow = ["2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "2.8", "2.9", "2.10"]
 
 [tool.hatch.envs.tests.overrides]
 matrix.airflow.dependencies = [
-    { value = "typing_extensions<4.6", if = [
-        "2.6",
-    ] },
+    { value = "typing_extensions<4.6", if = ["2.6"] },
 ]
 
 [tool.hatch.envs.tests.scripts]


### PR DESCRIPTION
I've been added mypy to test my dags and get errors about 
`Skipping analyzing "fivetran_provider_async.hooks": module is installed, but missing library stubs or py.typed marker`

I could add overrides to my project to ignore this package, but since people have gone to the bother of actually added type hints, it would be better to add a py.typed marker to the project.

https://peps.python.org/pep-0561/