### PR TITLE
Drop Airflow 2.2 and 2.3 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Build and test
 on:
   push:
-    branches: ['main']
+    branches: ['main', 'bump_airflow_version']
   pull_request:
     branches: ['main']
   release:
@@ -44,17 +44,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ "3.9", "3.10", "3.11", "3.12" ]
-        airflow-version: [ "2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "2.8", "2.9", "2.10" ]
+        airflow-version: [ "2.4", "2.5", "2.6", "2.7", "2.8", "2.9", "2.10" ]
         exclude:
-          # Apache Airflow versions prior to 2.3.0 have not been tested with Python 3.10
-          # See: https://airflow.apache.org/docs/apache-airflow/2.2.0/installation/prerequisites.html
-          - python-version: "3.10"
-            airflow-version: "2.2"
-          # Apache Airflow versions prior to 2.6.2 have not been tested with Python 3.11
-          - python-version: "3.11"
-            airflow-version: "2.2"
-          - python-version: "3.11"
-            airflow-version: "2.3"
           - python-version: "3.11"
             airflow-version: "2.4"
           - python-version: "3.11"
@@ -65,10 +56,6 @@ jobs:
           # Official support for Python 3.12 and the corresponding constraints.txt are available only for Apache Airflow >= 2.9.0.
           # See: https://github.com/apache/airflow/tree/2.9.0?tab=readme-ov-file#requirements
           # See: https://github.com/apache/airflow/tree/2.8.4?tab=readme-ov-file#requirements
-          - python-version: "3.12"
-            airflow-version: "2.2"
-          - python-version: "3.12"
-            airflow-version: "2.3"
           - python-version: "3.12"
             airflow-version: "2.4"
           - python-version: "3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "apache-airflow>=2.2.0",
+    "apache-airflow>=2.4.0",
     "aiohttp",
     "asgiref",
     "requests",
@@ -60,7 +60,7 @@ pre-install-commands = ["sh scripts/test/pre-install-airflow.sh {matrix:airflow}
 
 [[tool.hatch.envs.tests.matrix]]
 python = ["3.9", "3.10", "3.11", "3.12"]
-airflow = ["2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "2.8", "2.9", "2.10"]
+airflow = ["2.4", "2.5", "2.6", "2.7", "2.8", "2.9", "2.10"]
 
 [tool.hatch.envs.tests.overrides]
 matrix.airflow.dependencies = [


### PR DESCRIPTION
Drop the Airflow 2.2 and 2.3 support 
This is to make it consistent with other projects

[Airflow 2.3](https://pypi.org/project/apache-airflow/2.3.0/) was released on 1 May 2022.
Supported Python 3.7, 3.8, 3.9 (Python 3.7, 3.8 have reached EOL and [3.9 will reach EOL in October 2025](https://devguide.python.org/versions/))