### PR TITLE
Restrict the click version to fix the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Build and test
 on:
   push:
-    branches: ['main']
+    branches: ['main', fix_ci]
   pull_request:
     branches: ['main']
   release:
@@ -39,7 +39,7 @@ jobs:
           python-version: "3.11"
           architecture: "x64"
 
-      - run: pip3 install hatch
+      - run: pip3 install "hatch" "click!=8.3.0"
       - run: hatch run tests.py3.11-2.10:static-check
 
   Run-Unit-Tests:
@@ -94,7 +94,7 @@ jobs:
       - name: Install packages and dependencies
         run: |
           python -m pip install uv
-          uv pip install --system hatch
+          uv pip install --system "hatch" "click!=8.3.0"
           hatch -e tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }} run pip freeze
 
       - name: Test Airflow ${{ matrix.airflow-version }} and Python ${{ matrix.python-version }}
@@ -144,7 +144,7 @@ jobs:
       - name: Install packages and dependencies
         run: |
           python -m pip install uv
-          uv pip install --system hatch
+          uv pip install --system "hatch" "click!=8.3.0"
           hatch -e tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }} run pip freeze
 
       - name: Test Airflow ${{ matrix.airflow-version }} and Python ${{ matrix.python-version }}


### PR DESCRIPTION
This PR updates the CI workflow to fix installation errors caused by `click==8.3.0`.

- Replaces the command `uv tool install hatch` with:
  ```bash
  uv pip install --system "hatch" "click!=8.3.0"
