### PR TITLE
Make openlineage-airflow an optional dependency

### DIFF
--- a/fivetran_provider_async/__init__.py
+++ b/fivetran_provider_async/__init__.py
@@ -1,5 +1,5 @@
 # ruff: noqa F401
-__version__ = "2.2.1a1"
+__version__ = "2.2.1"
 
 import logging
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,15 @@ dependencies = [
     "aiohttp",
     "asgiref",
     "requests",
-    "openlineage-airflow>=0.19.2",
 ]
 
 [project.optional-dependencies]
+openlineage = [
+    "openlineage-airflow>=0.19.2",
+]
+all = [
+    "openlineage-airflow>=0.19.2",
+]
 tests = [
     "mypy",
     "types-requests",


### PR DESCRIPTION
## Summary

Move `openlineage-airflow` from a hard dependency back to an optional extra (`[openlineage]` / `[all]`).

This was optional in 2.1.1, became a hard dep in 2.1.2, but the code already handles its absence — `__init__.py` wraps the imports in `try/except ImportError`.

## Why

The hard dependency on `openlineage-airflow` causes pip resolution failures when combined with `apache-airflow-providers-openlineage`. The conflict:

- `openlineage-airflow` pins `openlineage-python` to exact old versions (e.g., `==1.40.0`)
- `apache-airflow-providers-openlineage>=2.9.0` requires `openlineage-python>=1.40.0` (and the latest integration-common)
- These two constraints are mutually exclusive because `openlineage-airflow` bundles its own `openlineage-integration-common` pinned to the same exact version

This affects any Airflow project that uses both `airflow-provider-fivetran-async` and a recent `providers-openlineage` — pip cannot resolve the dependency tree.

## Changes

- `pyproject.toml`: Move `openlineage-airflow>=0.19.2` from `dependencies` to `[project.optional-dependencies]` under `openlineage` and `all` extras
- `__init__.py`: Bump version to 2.2.1

Users who need OpenLineage integration with Fivetran can install with `pip install airflow-provider-fivetran-async[openlineage]`.