### PR TITLE
Drop Python 3.9 support and fix OpenLineage test deps in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.10", "3.11", "3.12" ]
         airflow-version: [ "2.4", "2.5", "2.6", "2.7", "2.8", "2.9", "2.10" ]
         exclude:
           - python-version: "3.11"
@@ -116,7 +116,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.10", "3.11", "3.12" ]
         # TODO: Enable tests for others version of Airflow
         # https://github.com/astronomer/airflow-provider-fivetran-async/issues/166
         airflow-version: [ "2.8", "2.9", "2.10" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [{ name = "Astronomer & Fivetran", email = "humans@astronomer.io" }]
 readme = "README.md"
 license = "Apache-2.0"
 license-files = { paths = ["LICENSE"] }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 keywords = ["airflow", "apache-airflow", "provider", "astronomer", "dag"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -22,7 +22,6 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -59,12 +58,12 @@ tests = [
 
 [tool.hatch.envs.tests]
 dependencies = [
-    "airflow-provider-fivetran-async[tests]",
+    "airflow-provider-fivetran-async[tests,all]",
 ]
 pre-install-commands = ["sh scripts/test/pre-install-airflow.sh {matrix:airflow} {matrix:python}"]
 
 [[tool.hatch.envs.tests.matrix]]
-python = ["3.9", "3.10", "3.11", "3.12"]
+python = ["3.10", "3.11", "3.12"]
 airflow = ["2.4", "2.5", "2.6", "2.7", "2.8", "2.9", "2.10"]
 
 [tool.hatch.envs.tests.overrides]
@@ -111,7 +110,7 @@ markers = ["integration"]
 
 [tool.black]
 line-length = 120
-target-version = ['py39', 'py310', 'py311', 'py312']
+target-version = ['py310', 'py311', 'py312']
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
## Summary

Fixes two CI failures introduced by #207 ("Make openlineage-airflow an optional dependency"):

- **OpenLineage tests fail with ImportError** — the hatch test environment installed `[tests]` but not `[all]`, so `openlineage-airflow` was missing. Changed to `[tests,all]` so CI has the optional dependency available.
- **All Python 3.9 jobs fail** with `module 'virtualenv.discovery.builtin' has no attribute 'propose_interpreters'` — `virtualenv>=21` dropped Python 3.9 support after its October 2025 EOL.

## Changes

**`pyproject.toml`:**
- `requires-python`: `>=3.9` → `>=3.10`
- Removed `Programming Language :: Python :: 3.9` classifier
- Hatch test deps: `[tests]` → `[tests,all]` to include `openlineage-airflow`
- Removed `3.9` from hatch test matrix
- Removed `py39` from black `target-version`

**`.github/workflows/ci.yml`:**
- Removed `3.9` from unit and integration test matrix