### PR TITLE
Replace pre-commit with prek

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ tests = [
     "pytest-asyncio",
     "pytest-cov",
     "requests_mock",
-    "pre-commit",
+    "prek",
 ]
 
 ######################################
@@ -78,7 +78,7 @@ matrix.airflow.dependencies = [
 
 [tool.hatch.envs.tests.scripts]
 freeze = "pip freeze"
-static-check = " pre-commit run --files fivetran_provider_async/*"
+static-check = "prek run --files fivetran_provider_async/*"
 test = 'sh scripts/test/unit.sh'
 test-integration = 'sh scripts/test/integration.sh'
 test-integration-setup = 'sh scripts/test/integration-setup.sh'


### PR DESCRIPTION
## Summary

Replaces `pre-commit` with [`prek`](https://prek.j178.dev/) — a drop-in alternative that ships as a single binary with no Python runtime dependency.

prek is fully compatible with `.pre-commit-config.yaml`, so no changes needed to the hook config.

## Changes

- `pyproject.toml`: swap `pre-commit` → `prek` in test dependencies
- `pyproject.toml`: swap `pre-commit run` → `prek run` in the static-check script

## Why prek

- Single binary, no Python dependency for the tool itself
- Faster hook execution with parallel runs
- Drop-in compatible with existing `.pre-commit-config.yaml`
- No more pre-commit.ci autoupdate PRs cluttering the repo