### PR TITLE
Drop support for AF < 2.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Build and test
 on:
   push:
-    branches: ['main']
+    branches: ['main', 'drop_lt_af2.9']
   pull_request:
     branches: ['main']
   release:
@@ -51,37 +51,9 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ "3.10", "3.11", "3.12", "3.13" ]
-        airflow-version: [ "2.4", "2.5", "2.6", "2.7", "2.8", "2.9", "2.10", "3.0" ]
+        airflow-version: [ "2.9", "2.10", "3.0" ]
         exclude:
-          - python-version: "3.11"
-            airflow-version: "2.4"
-          - python-version: "3.11"
-            airflow-version: "2.5"
-          - python-version: "3.11"
-            airflow-version: "2.6"
-          # Apache Airflow versions prior to 2.9.0 have not been tested with Python 3.12.
-          # Official support for Python 3.12 and the corresponding constraints.txt are available only for Apache Airflow >= 2.9.0.
-          - python-version: "3.12"
-            airflow-version: "2.4"
-          - python-version: "3.12"
-            airflow-version: "2.5"
-          - python-version: "3.12"
-            airflow-version: "2.6"
-          - python-version: "3.12"
-            airflow-version: "2.7"
-          - python-version: "3.12"
-            airflow-version: "2.8"
           # Python 3.13 is only supported by Apache Airflow >= 3.0.
-          - python-version: "3.13"
-            airflow-version: "2.4"
-          - python-version: "3.13"
-            airflow-version: "2.5"
-          - python-version: "3.13"
-            airflow-version: "2.6"
-          - python-version: "3.13"
-            airflow-version: "2.7"
-          - python-version: "3.13"
-            airflow-version: "2.8"
           - python-version: "3.13"
             airflow-version: "2.9"
           - python-version: "3.13"
@@ -134,11 +106,7 @@ jobs:
         # https://github.com/astronomer/airflow-provider-fivetran-async/issues/166
         airflow-version: [ "2.8", "2.9", "2.10", "3.0" ]
         exclude:
-          - python-version: "3.12"
-            airflow-version: "2.8"
           # Python 3.13 is only supported by Apache Airflow >= 3.0.
-          - python-version: "3.13"
-            airflow-version: "2.8"
           - python-version: "3.13"
             airflow-version: "2.9"
           - python-version: "3.13"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
         python-version: [ "3.10", "3.11", "3.12", "3.13" ]
         # TODO: Enable tests for others version of Airflow
         # https://github.com/astronomer/airflow-provider-fivetran-async/issues/166
-        airflow-version: [ "2.8", "2.9", "2.10", "3.0" ]
+        airflow-version: [ "2.9", "2.10", "3.0" ]
         exclude:
           # Python 3.13 is only supported by Apache Airflow >= 3.0.
           - python-version: "3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,16 +65,11 @@ pre-install-commands = ["sh scripts/test/pre-install-airflow.sh {matrix:airflow}
 
 [[tool.hatch.envs.tests.matrix]]
 python = ["3.10", "3.11", "3.12"]
-airflow = ["2.4", "2.5", "2.6", "2.7", "2.8", "2.9", "2.10", "3.0"]
+airflow = ["2.9", "2.10", "3.0"]
 
 [[tool.hatch.envs.tests.matrix]]
 python = ["3.13"]
 airflow = ["3.0"]
-
-[tool.hatch.envs.tests.overrides]
-matrix.airflow.dependencies = [
-    { value = "typing_extensions<4.6", if = ["2.6"] },
-]
 
 [tool.hatch.envs.tests.scripts]
 freeze = "pip freeze"


### PR DESCRIPTION
Updates the project’s CI/test configuration to stop validating against Apache Airflow versions earlier than 2.9.

**Changes:**
- Reduced Hatch test matrix Airflow versions to `2.9`, `2.10`, `3.0`.
- Reduced CI unit-test matrix Airflow versions to `2.9`, `2.10`, `3.0` and removed now-unneeded exclusions.