### PR TITLE
Retry on ClientConnectionError

### DIFF
--- a/fivetran_provider_async/hooks.py
+++ b/fivetran_provider_async/hooks.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, Dict
 import aiohttp
 import pendulum
 import requests
-from aiohttp import ClientResponseError
+from aiohttp import ClientResponseError, ClientConnectorError
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
 from airflow.models.connection import Connection
@@ -166,7 +166,8 @@ class FivetranHook(BaseHook):
                     raise AirflowException(
                         f"Response: {e.response.content.decode()}, " f"Status Code: {e.response.status_code}"
                     ) from e
-
+                self._log_request_error(attempt_num, str(e))
+            except requests.exceptions.ConnectionError as e:
                 self._log_request_error(attempt_num, str(e))
 
             if attempt_num == self.retry_limit:
@@ -676,6 +677,8 @@ class FivetranHookAsync(FivetranHook):
                         # In this case, the user probably made a mistake.
                         # Don't retry.
                         return {"Response": {e.message}, "Status Code": {e.status}}
+                    self._log_request_error(attempt_num, str(e))
+                except ClientConnectorError as e:
                     self._log_request_error(attempt_num, str(e))
 
                 if attempt_num == self.retry_limit:

--- a/fivetran_provider_async/hooks.py
+++ b/fivetran_provider_async/hooks.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, Dict
 import aiohttp
 import pendulum
 import requests
-from aiohttp import ClientResponseError, ClientConnectorError
+from aiohttp import ClientConnectorError, ClientResponseError
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
 from airflow.models.connection import Connection

--- a/fivetran_provider_async/hooks.py
+++ b/fivetran_provider_async/hooks.py
@@ -167,8 +167,6 @@ class FivetranHook(BaseHook):
                         f"Response: {e.response.content.decode()}, " f"Status Code: {e.response.status_code}"
                     ) from e
                 self._log_request_error(attempt_num, str(e))
-            except requests.exceptions.ConnectionError as e:
-                self._log_request_error(attempt_num, str(e))
 
             if attempt_num == self.retry_limit:
                 raise AirflowException(f"API request to Fivetran failed {self.retry_limit} times." " Giving up.")

--- a/tests/hooks/test_fivetran.py
+++ b/tests/hooks/test_fivetran.py
@@ -6,7 +6,7 @@ import multidict
 import pendulum
 import pytest
 import requests_mock
-from aiohttp import BasicAuth, ClientResponseError, RequestInfo, ClientConnectorError
+from aiohttp import BasicAuth, ClientConnectorError, ClientResponseError, RequestInfo
 from airflow.exceptions import AirflowException
 from airflow.utils.helpers import is_container
 

--- a/tests/hooks/test_fivetran.py
+++ b/tests/hooks/test_fivetran.py
@@ -1,11 +1,12 @@
 import unittest
 from unittest import mock
 
+import aiohttp
 import multidict
 import pendulum
 import pytest
 import requests_mock
-from aiohttp import BasicAuth, ClientResponseError, RequestInfo
+from aiohttp import BasicAuth, ClientResponseError, RequestInfo, ClientConnectorError
 from airflow.exceptions import AirflowException
 from airflow.utils.helpers import is_container
 
@@ -670,6 +671,27 @@ class TestFivetranHookAsync:
         # Pass in auth kwarg of a different type (using a string for the test)
         kwargs = hook._prepare_api_call_kwargs_async("POST", "v1/connectors/test", auth="BadAuth")
         assert isinstance(kwargs["auth"], BasicAuth)
+
+    @pytest.mark.asyncio
+    @mock.patch("fivetran_provider_async.hooks.aiohttp.ClientSession")
+    @mock.patch("fivetran_provider_async.hooks.FivetranHookAsync.get_connection")
+    async def test_do_api_call_async_with_retry_on_connection_refused(self, mock_get_connection, mock_session):
+        """Tests that _do_api_call_async method raises exception for a retryable error"""
+        mock_session.return_value.__aenter__.return_value.request.side_effect = ClientConnectorError(
+            aiohttp.client_reqrep.ConnectionKey(host='api.fivetran.com', port=443, ssl=True, is_ssl=True, proxy=None, proxy_auth=None, proxy_headers_hash=None),
+            ConnectionRefusedError(61, "Connect call failed ('api.fivetran.com', 443)")
+        )
+
+        hook = FivetranHookAsync(fivetran_conn_id="conn_fivetran")
+
+        hook.fivetran_conn = mock_get_connection
+        hook.fivetran_conn.login = LOGIN
+        hook.fivetran_conn.password = PASSWORD
+
+        with pytest.raises(AirflowException) as exc:
+            await hook._do_api_call_async(("PATCH", "v1/connectors/test"))
+
+        assert str(exc.value) == "API requests to Fivetran failed 3 times. Giving up."
 
 
 # Mock the `conn_fivetran` Airflow connection (note the `@` after `API_SECRET`)


### PR DESCRIPTION
closes #219

We've been seeing connection errors where a sync will start and the operator defers, then while waiting for the sync to complete, there is a hiccup while connecting to the fivetran API.  
```
[2026-03-26, 12:00:49 UTC] {hooks.py:501} INFO - Connector ...: sync_state = syncing
[2026-03-26, 12:00:49 UTC] {triggers.py:90} INFO - sync is still running...
[2026-03-26, 12:00:49 UTC] {triggers.py:91} INFO - sleeping for 15 seconds.
[2026-03-26, 12:01:12 UTC] {hooks.py:501} INFO - Connector ...: sync_state = syncing
[2026-03-26, 12:01:12 UTC] {triggers.py:90} INFO - sync is still running...
[2026-03-26, 12:01:12 UTC] {triggers.py:91} INFO - sleeping for 15 seconds.
[2026-03-26, 12:01:27 UTC] {triggerer_job_runner.py:631} INFO - Trigger dbt_scd2_fivetran_airflow_rest_api/scheduled__2026-03-26T11:00:00+00:00/airflow_rest_api.fivetran/0/1 (ID 118894) fired: TriggerEvent<{'status': 'error', 'message': "Cannot connect to host api.fivetran.com:443 ssl:default [Connect call failed ('35.245.223.13', 443)]"}>
[2026-03-26, 12:01:29 UTC] {local_task_job_runner.py:123} ▶ Pre task execution logs
[2026-03-26, 12:01:30 UTC] {taskinstance.py:3337} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/airflow/models/taskinstance.py", line 776, in _execute_task
    result = _execute_callable(context=context, **execute_callable_kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/airflow/models/taskinstance.py", line 742, in _execute_callable
    return ExecutionCallableRunner(
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/airflow/utils/operator_helpers.py", line 252, in run
    return self.func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/airflow/models/baseoperator.py", line 1820, in resume_execution
    return execute_callable(context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/fivetran_provider_async/operators.py", line 193, in execute_complete
    raise AirflowException(msg)
airflow.exceptions.AirflowException: error: Cannot connect to host api.fivetran.com:443 ssl:default [Connect call failed ('35.245.223.13', 443)]
```
It's hard to say exactly why this happens, but I think the operator should be a little more forgiving when it does.