### PR TITLE
Use pull_request_target to allow secrets access on fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Build and test
 on:
   push:
     branches: ['main', 'drop_lt_af2.9']
-  pull_request:
+  pull_request_target:
     branches: ['main']
   release:
     types: [ 'created' ]
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   Authorize:
-    environment: ${{ github.event_name == 'pull_request' &&
+    environment: ${{ github.event_name == 'pull_request_target' &&
       github.event.pull_request.head.repo.full_name != github.repository &&
       'external' || 'internal' }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
Switch CI trigger from pull_request to pull_request_target so that the FIVETRAN_DEFAULT secret is available for integration tests on PRs from external contributors. The Authorize job's external environment gate still requires maintainer approval before fork PR code runs with secrets.

Related: https://github.com/astronomer/oss-integrations-private/issues/362