### PR TITLE
Retry on broken connector

### DIFF
--- a/fivetran_provider_async/hooks.py
+++ b/fivetran_provider_async/hooks.py
@@ -205,6 +205,13 @@ class FivetranHook(BaseHook):
         resp = self._do_api_call("GET", endpoint)
         return resp["data"]
 
+    def test_connector(self, connector_id: str) -> dict[str, Any]:
+        if connector_id == "":
+            raise ValueError("No value specified for connector_id")
+        endpoint = self.api_path_connectors + connector_id + "/test"
+        resp = self._do_api_call("POST", endpoint)
+        return resp["data"]
+
     def get_connector_schemas(self, connector_id: str) -> dict[str, Any]:
         """
         Fetches schema information of the connector.
@@ -316,6 +323,10 @@ class FivetranHook(BaseHook):
         schema_name = connector_details["schema"]
         setup_state = connector_details["status"]["setup_state"]
         if setup_state != "connected":
+            connector_details = self.test_connector(connector_id)
+            setup_state = connector_details["status"]["setup_state"]
+
+        if setup_state != "connected":
             raise AirflowException(
                 f'Fivetran connector "{connector_id}" not correctly configured, '
                 f"status: {setup_state}\nPlease see: "
@@ -347,6 +358,7 @@ class FivetranHook(BaseHook):
             page in the Fivetran user interface.
         :param schedule_type: Fivetran connector schedule type
         """
+
         connector_details = self.check_connector(connector_id)
         if schedule_type not in {"manual", "auto"}:
             raise ValueError('schedule_type must be either "manual" or "auto"')

--- a/fivetran_provider_async/hooks.py
+++ b/fivetran_provider_async/hooks.py
@@ -209,7 +209,7 @@ class FivetranHook(BaseHook):
         if connector_id == "":
             raise ValueError("No value specified for connector_id")
         endpoint = self.api_path_connectors + connector_id + "/test"
-        resp = self._do_api_call("POST", endpoint)
+        resp = self._do_api_call("POST", endpoint, json={})
         return resp["data"]
 
     def get_connector_schemas(self, connector_id: str) -> dict[str, Any]:

--- a/fivetran_provider_async/hooks.py
+++ b/fivetran_provider_async/hooks.py
@@ -322,16 +322,17 @@ class FivetranHook(BaseHook):
         service_name = connector_details["service"]
         schema_name = connector_details["schema"]
         setup_state = connector_details["status"]["setup_state"]
+
         if setup_state != "connected":
             connector_details = self.test_connector(connector_id)
             setup_state = connector_details["status"]["setup_state"]
-
-        if setup_state != "connected":
-            raise AirflowException(
-                f'Fivetran connector "{connector_id}" not correctly configured, '
-                f"status: {setup_state}\nPlease see: "
-                f"{self._connector_ui_url_setup(service_name, schema_name)}"
-            )
+            if setup_state != "connected":
+                raise AirflowException(
+                    f'Fivetran connector "{connector_id}" not correctly configured, '
+                    f"status: {setup_state}\nPlease see: "
+                    f"{self._connector_ui_url_setup(service_name, schema_name)}"
+                )
+            self.log.info("Connector %s passed test connection and is now connected", connector_id)
         self.log.info("Connector type: %s, connector schema: %s", service_name, schema_name)
         self.log.info("Connectors logs at %s", self._connector_ui_url_logs(service_name, schema_name))
         return connector_details

--- a/tests/hooks/test_fivetran.py
+++ b/tests/hooks/test_fivetran.py
@@ -1,3 +1,4 @@
+import copy
 import unittest
 from unittest import mock
 
@@ -860,3 +861,34 @@ class TestFivetranHook(unittest.TestCase):
         assert m.last_request.json() == payload
         assert m.last_request.method == "POST"
         assert result is not None
+
+
+    @requests_mock.mock()
+    def test_reconnect_connector(self, m):
+        payload = copy.deepcopy(MOCK_FIVETRAN_RESPONSE_PAYLOAD)
+        payload["data"]["status"]["setup_state"] = "broken"
+        m.get(
+            "https://api.fivetran.com/v1/connectors/interchangeable_revenge",
+            json=payload,
+        )
+        m.post(
+            "https://api.fivetran.com/v1/connectors/interchangeable_revenge/test",
+            json=payload,
+        )
+
+        hook = FivetranHook(
+            fivetran_conn_id="conn_fivetran",
+        )
+
+        with pytest.raises(AirflowException, match="not correctly configured, status: broken"):
+            hook.prep_connector(connector_id="interchangeable_revenge", schedule_type="manual")
+
+        m.reset_mock()
+        m.post(
+            "https://api.fivetran.com/v1/connectors/interchangeable_revenge/test",
+            json=MOCK_FIVETRAN_RESPONSE_PAYLOAD,
+        )
+
+        hook.prep_connector(connector_id="interchangeable_revenge", schedule_type="manual")
+        assert m.request_history[-2].path == "/v1/connectors/interchangeable_revenge"
+        assert m.request_history[-1].path == "/v1/connectors/interchangeable_revenge/test"


### PR DESCRIPTION
Closes #150 

We occasionally have issues where a fivetran connector fails and all it takes for the connector to start running again is an on call person to reconnect.  In fivetran all they are actually doing is clicking sync, which I believe just tests the connection and then proceeds with a sync if it is successful, so I am attempting to do the same in the hopes that it can be handled automatically and not surface up to somebody on call. 