### PR TITLE
Reduce unittests runtime from 134s to 13s

### DIFF
--- a/tests/hooks/test_fivetran.py
+++ b/tests/hooks/test_fivetran.py
@@ -394,8 +394,10 @@ class TestFivetranHookAsync:
     )
     @mock.patch("fivetran_provider_async.hooks.FivetranHookAsync._do_api_call_async")
     @mock.patch("fivetran_provider_async.hooks.FivetranHookAsync.start_fivetran_sync")
+    @mock.patch("fivetran_provider_async.hooks.time.sleep")
     async def test_fivetran_hook_get_sync_status_async_with_reschedule_for_and_schedule_type_manual(
         self,
+        mock_sleep,
         mock_start_fivetran_sync,
         mock_api_call_async_response,
         mock_previous_completed_at,


### PR DESCRIPTION
While running the unit tests locally, I noticed they were particularly slow (over two minutes to run), and that `tests/hooks/test_fivetran.py::TestFivetranHookAsync::test_fivetran_hook_get_sync_status_async_with_reschedule_for_and_schedule_type_manual[mock_previous_completed_at1-pending]` seemed to hang for a while.

Example of time when running:

```
hatch run tests.py3.10-2.10:test
```

Before the change:
```
==================================== 64 passed, 15 warnings in 134.70s (0:02:14) ====================================
```

After the change:
```
========================================= 64 passed, 15 warnings in 13.39s ==========================================
```

Solution: mock time.sleep in reschedule test to avoid ~60s delay

The test was calling the real `pause_and_restart` which sleeps until the `rescheduled_for` timestamp (set to now + 1 minute in test data).