### PR TITLE
Fix installed airflow version in test jobs

### DIFF
--- a/fivetran_provider_async/__init__.py
+++ b/fivetran_provider_async/__init__.py
@@ -6,9 +6,18 @@ import logging
 log = logging.getLogger(__name__)
 
 try:
-    from openlineage.airflow.extractors.base import (  # type: ignore[import]
+    from airflow.providers.openlineage.extractors.base import (  # type: ignore[import]
         OperatorLineage,
     )
+except ImportError:
+    try:
+        from openlineage.airflow.extractors.base import (  # type: ignore[import,no-redef]
+            OperatorLineage,
+        )
+    except ImportError:
+        logging.debug("apache-airflow-providers-openlineage or openlineage-airflow python dependency is missing")
+
+try:
     from openlineage.client.facet import (
         DataSourceDatasetFacet,
         DocumentationJobFacet,
@@ -20,7 +29,7 @@ try:
     )
     from openlineage.client.run import Dataset
 except ImportError:
-    logging.debug("openlineage-airflow python dependency is missing")
+    logging.debug("openlineage-python dependency is missing")
 
 
 def get_provider_info():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ tests = [
 [tool.hatch.envs.tests]
 dependencies = [
     "airflow-provider-fivetran-async[tests,all]",
+    "apache-airflow~={matrix:airflow}.0",
 ]
 pre-install-commands = ["sh scripts/test/pre-install-airflow.sh {matrix:airflow} {matrix:python}"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,9 +58,21 @@ tests = [
 ######################################
 
 [tool.hatch.envs.tests]
+# Do not install Airflow dependencies here!
+# We need to use constraints and we're doing this in the `pre-install-commands`
 dependencies = [
-    "airflow-provider-fivetran-async[tests,all]",
-    "apache-airflow~={matrix:airflow}.0",
+    "aiohttp",
+    "asgiref",
+    "requests",
+    "openlineage-airflow>=0.19.2",
+    "mypy",
+    "types-requests",
+    "parameterized",
+    "pytest",
+    "pytest-asyncio",
+    "pytest-cov",
+    "requests_mock",
+    "prek",
 ]
 pre-install-commands = ["sh scripts/test/pre-install-airflow.sh {matrix:airflow} {matrix:python}"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,13 +58,12 @@ tests = [
 ######################################
 
 [tool.hatch.envs.tests]
-# Do not install Airflow dependencies here!
-# We need to use constraints and we're doing this in the `pre-install-commands`
+# Do not install Airflow or OpenLineage dependencies here!
+# They are installed in the `pre-install-commands` to control the Airflow version
 dependencies = [
     "aiohttp",
     "asgiref",
     "requests",
-    "openlineage-airflow>=0.19.2",
     "mypy",
     "types-requests",
     "parameterized",

--- a/scripts/test/integration-setup.sh
+++ b/scripts/test/integration-setup.sh
@@ -16,4 +16,12 @@ fi
 rm -rf airflow.*
 pip freeze | grep airflow
 airflow db reset -y
-airflow db init || airflow db migrate
+
+AIRFLOW_MAJOR_VERSION=$(airflow version 2>/dev/null | tail -1 | cut -d. -f1)
+if [ "$AIRFLOW_MAJOR_VERSION" -ge 3 ]; then
+  echo "Detected Airflow 3.x. Running 'airflow db migrate'..."
+  airflow db migrate
+else
+  echo "Detected Airflow 2.x. Running 'airflow db init'..."
+  airflow db init
+fi

--- a/scripts/test/pre-install-airflow.sh
+++ b/scripts/test/pre-install-airflow.sh
@@ -13,14 +13,19 @@ fi
 
 echo "${VIRTUAL_ENV}"
 
-# Find the latest micro release for the desired Airflow minor version
-LATEST_AIRFLOW_VERSION=$(curl -s "https://pypi.org/pypi/apache-airflow/json" | \
-  python3 -c "import sys,json,re; d=json.load(sys.stdin); vs=[v for v in d['releases'] if v.startswith('${AIRFLOW_VERSION}.') and re.fullmatch(r'\d+\.\d+\.\d+', v) and not any(f.get('yanked') for f in d['releases'][v])]; vs.sort(key=lambda v:[int(x) for x in v.split('.')]); print(vs[-1])")
-echo "Latest Airflow ${AIRFLOW_VERSION}.x release: ${LATEST_AIRFLOW_VERSION}"
+# Find the Airflow version to install
+# Pin 3.0 to 3.0.0 due to dag.test() regression in later 3.0.x task-sdk releases
+if [ "$AIRFLOW_VERSION" = "3.0" ]; then
+  INSTALL_AIRFLOW_VERSION="3.0.0"
+else
+  INSTALL_AIRFLOW_VERSION=$(curl -s "https://pypi.org/pypi/apache-airflow/json" | \
+    python3 -c "import sys,json,re; d=json.load(sys.stdin); vs=[v for v in d['releases'] if v.startswith('${AIRFLOW_VERSION}.') and re.fullmatch(r'\d+\.\d+\.\d+', v) and not any(f.get('yanked') for f in d['releases'][v])]; vs.sort(key=lambda v:[int(x) for x in v.split('.')]); print(vs[-1])")
+fi
+echo "Installing Airflow: ${INSTALL_AIRFLOW_VERSION}"
 
 # Install Airflow
 pip install uv
-uv pip install "apache-airflow==${LATEST_AIRFLOW_VERSION}"
+uv pip install "apache-airflow==${INSTALL_AIRFLOW_VERSION}"
 
 # cncf-kubernetes provider is bundled in Airflow 3.x
 if [[ "$AIRFLOW_VERSION" == 2.* ]]; then

--- a/scripts/test/pre-install-airflow.sh
+++ b/scripts/test/pre-install-airflow.sh
@@ -13,17 +13,26 @@ fi
 
 echo "${VIRTUAL_ENV}"
 
-CONSTRAINT_URL="https://raw.githubusercontent.com/apache/airflow/constraints-$AIRFLOW_VERSION.0/constraints-$PYTHON_VERSION.txt"
-curl -sSL $CONSTRAINT_URL -o /tmp/constraint.txt
-# Workaround to remove PyYAML constraint that will work on both Linux and MacOS
-sed '/PyYAML==/d' /tmp/constraint.txt > /tmp/constraint.txt.tmp
-mv /tmp/constraint.txt.tmp /tmp/constraint.txt
-# Install Airflow with constraints
+# Find the latest micro release for the desired Airflow minor version
+LATEST_AIRFLOW_VERSION=$(curl -s "https://pypi.org/pypi/apache-airflow/json" | \
+  python3 -c "import sys,json,re; d=json.load(sys.stdin); vs=[v for v in d['releases'] if v.startswith('${AIRFLOW_VERSION}.') and re.fullmatch(r'\d+\.\d+\.\d+', v) and not any(f.get('yanked') for f in d['releases'][v])]; vs.sort(key=lambda v:[int(x) for x in v.split('.')]); print(vs[-1])")
+echo "Latest Airflow ${AIRFLOW_VERSION}.x release: ${LATEST_AIRFLOW_VERSION}"
+
+# Install Airflow
 pip install uv
-uv pip install "apache-airflow==$AIRFLOW_VERSION" --constraint /tmp/constraint.txt
+uv pip install "apache-airflow==${LATEST_AIRFLOW_VERSION}"
 
 # cncf-kubernetes provider is bundled in Airflow 3.x
 if [[ "$AIRFLOW_VERSION" == 2.* ]]; then
-  pip install apache-airflow-providers-cncf-kubernetes --constraint /tmp/constraint.txt
+  pip install apache-airflow-providers-cncf-kubernetes
 fi
-rm /tmp/constraint.txt
+
+actual_airflow_version=$(airflow version 2>/dev/null | tail -1 | cut -d. -f1,2)
+desired_airflow_version=$(echo $AIRFLOW_VERSION | cut -d. -f1,2)
+
+if [ "$actual_airflow_version" = "$desired_airflow_version" ]; then
+    echo "Version is as expected: $desired_airflow_version"
+else
+    echo "ERROR: Expected Airflow $desired_airflow_version but got $actual_airflow_version"
+    exit 1
+fi

--- a/scripts/test/pre-install-airflow.sh
+++ b/scripts/test/pre-install-airflow.sh
@@ -27,9 +27,11 @@ echo "Installing Airflow: ${INSTALL_AIRFLOW_VERSION}"
 pip install uv
 uv pip install "apache-airflow==${INSTALL_AIRFLOW_VERSION}"
 
-# cncf-kubernetes provider is bundled in Airflow 3.x
+# Install OpenLineage provider
 if [[ "$AIRFLOW_VERSION" == 2.* ]]; then
-  uv pip install apache-airflow-providers-cncf-kubernetes
+  uv pip install "openlineage-airflow>=0.19.2"
+else
+  uv pip install apache-airflow-providers-openlineage
 fi
 
 actual_airflow_version=$(airflow version 2>/dev/null | tail -1 | cut -d. -f1,2)

--- a/scripts/test/pre-install-airflow.sh
+++ b/scripts/test/pre-install-airflow.sh
@@ -27,11 +27,11 @@ echo "Installing Airflow: ${INSTALL_AIRFLOW_VERSION}"
 pip install uv
 uv pip install "apache-airflow==${INSTALL_AIRFLOW_VERSION}"
 
-# Install OpenLineage provider
+# Install OpenLineage provider, pinning Airflow to avoid upgrades
 if [[ "$AIRFLOW_VERSION" == 2.* ]]; then
-  uv pip install "openlineage-airflow>=0.19.2"
+  uv pip install "openlineage-airflow>=0.19.2" "apache-airflow==${INSTALL_AIRFLOW_VERSION}"
 else
-  uv pip install apache-airflow-providers-openlineage
+  uv pip install apache-airflow-providers-openlineage "apache-airflow==${INSTALL_AIRFLOW_VERSION}"
 fi
 
 actual_airflow_version=$(airflow version 2>/dev/null | tail -1 | cut -d. -f1,2)

--- a/scripts/test/pre-install-airflow.sh
+++ b/scripts/test/pre-install-airflow.sh
@@ -24,7 +24,7 @@ uv pip install "apache-airflow==${LATEST_AIRFLOW_VERSION}"
 
 # cncf-kubernetes provider is bundled in Airflow 3.x
 if [[ "$AIRFLOW_VERSION" == 2.* ]]; then
-  pip install apache-airflow-providers-cncf-kubernetes
+  uv pip install apache-airflow-providers-cncf-kubernetes
 fi
 
 actual_airflow_version=$(airflow version 2>/dev/null | tail -1 | cut -d. -f1,2)

--- a/tests/hooks/test_fivetran.py
+++ b/tests/hooks/test_fivetran.py
@@ -394,8 +394,10 @@ class TestFivetranHookAsync:
     )
     @mock.patch("fivetran_provider_async.hooks.FivetranHookAsync._do_api_call_async")
     @mock.patch("fivetran_provider_async.hooks.FivetranHookAsync.start_fivetran_sync")
+    @mock.patch("fivetran_provider_async.hooks.time.sleep")
     async def test_fivetran_hook_get_sync_status_async_with_reschedule_for_and_schedule_type_manual(
         self,
+        mock_sleep,
         mock_start_fivetran_sync,
         mock_api_call_async_response,
         mock_previous_completed_at,

--- a/tests/hooks/test_fivetran.py
+++ b/tests/hooks/test_fivetran.py
@@ -394,10 +394,8 @@ class TestFivetranHookAsync:
     )
     @mock.patch("fivetran_provider_async.hooks.FivetranHookAsync._do_api_call_async")
     @mock.patch("fivetran_provider_async.hooks.FivetranHookAsync.start_fivetran_sync")
-    @mock.patch("fivetran_provider_async.hooks.time.sleep")
     async def test_fivetran_hook_get_sync_status_async_with_reschedule_for_and_schedule_type_manual(
         self,
-        mock_sleep,
         mock_start_fivetran_sync,
         mock_api_call_async_response,
         mock_previous_completed_at,


### PR DESCRIPTION
Install the correct version of Airflow
    
I noticed that the job `hatch run tests.py3.13-3.0:test` was failing in the CI with several errors:
    
```
    FAILED tests/operators/test_fivetran.py::TestFivetranOperator::test_fivetran_operator_get_openlineage_facets_on_start - ImportError: cannot import name 'DocumentationJobFacet' from 'fivetran_provider_async' (/Users/tatiana.alchueyr/Code/airflow-provider-fivetran-async/fivetran_provider_async/__init__.py)
    FAILED tests/utils/test_operator_utils.py::TestFivetranUtils::test_utils_get_fields_destination - ImportError: cannot import name 'SchemaDatasetFacet' from 'fivetran_provider_async' (/Users/tatiana.alchueyr/Code/airflow-provider-fivetran-async/fivetran_provider_async/__init__.py)
    FAILED tests/utils/test_operator_utils.py::TestFivetranUtils::test_utils_get_fields_source - ImportError: cannot import name 'SchemaDatasetFacet' from 'fivetran_provider_async' (/Users/tatiana.alchueyr/Code/airflow-provider-fivetran-async/fivetran_provider_async/__init__.py)
    FAILED tests/utils/test_operator_utils.py::TestFivetranUtils::test_utils_input_dataset - ImportError: cannot import name 'Dataset' from 'fivetran_provider_async' (/Users/tatiana.alchueyr/Code/airflow-provider-fivetran-async/fivetran_provider_async/__init__.py)
    FAILED tests/utils/test_operator_utils.py::TestFivetranUtils::test_utils_output_dataset - ImportError: cannot import name 'Dataset' from 'fivetran_provider_async' (/Users/tatiana.alchueyr/Code/airflow-provider-fivetran-async/fivetran_provider_async/__init__.py)
```
    
I was able to reproduce locally and noticed that the problem is that the Hatch matrix specifies airflow = ["3.0"], and pre-install-airflow.sh installs apache-airflow==3.0 with constraints. But then Hatch installs the project dependencies (which only require apache-airflow>=2.4.0), and the resolver is free to upgrade Airflow to 3.2.0.
    
This PR aims to solve this.