### PR TITLE
Pin Airflow version per matrix to prevent uv from upgrading to latest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,13 @@ airflow = ["2.9", "2.10", "3.0"]
 python = ["3.13"]
 airflow = ["3.0"]
 
+[tool.hatch.envs.tests.overrides.matrix.airflow]
+extra-dependencies = [
+    {value = "apache-airflow>=2.9,<2.10",  if = ["2.9"]},
+    {value = "apache-airflow>=2.10,<2.11", if = ["2.10"]},
+    {value = "apache-airflow>=3.0,<3.1",   if = ["3.0"]},
+]
+
 [tool.hatch.envs.tests.scripts]
 freeze = "pip freeze"
 static-check = "prek run --files fivetran_provider_async/*"


### PR DESCRIPTION
Adds hatch matrix overrides so the dependency resolver constrains apache-airflow to the expected minor version range (e.g. >=3.0,<3.1) instead of resolving the latest available release when installing airflow-provider-fivetran-async[tests,all].