### PR TITLE
Drop support for Airflow < 2.9 in dependencies and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Build and test
 on:
   push:
-    branches: ['main', 'drop_lt_af2.9']
+    branches: ['main']
   pull_request_target:
     branches: ['main']
   release:

--- a/docs/how_to_contribute.md
+++ b/docs/how_to_contribute.md
@@ -99,10 +99,10 @@ The [pyproject. toml](https://github.com/astronomer/dag-factory/blob/main/pyproj
 
 ### Run unit tests
 
-To run unit tests using Python 3.10 and Airflow 2.5, use the following:
+To run unit tests using Python 3.10 and Airflow 2.9, use the following:
 
 ```bash
-hatch run tests.py3.10-2.5:test-cov
+hatch run tests.py3.10-2.9:test-cov
 ```
 
 It is also possible to run the tests using all the matrix combinations, by using:
@@ -127,7 +127,7 @@ pre-commit run --all-files
 Pre-commit runs several static checks, including Black and Ruff. It is also possible to run them using ``hatch``:
 
 ```bash
-hatch run tests.py3.9-2.9:static-check
+hatch run tests.py3.10-2.9:static-check
 ```
 
 ## Releasing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "apache-airflow>=2.4.0",
+    "apache-airflow>=2.9.0",
     "aiohttp",
     "asgiref",
     "requests",


### PR DESCRIPTION
- Bump minimum Airflow requirement from >=2.4.0 to >=2.9.0
- Update how_to_contribute.md examples to use Airflow 2.9 / Python 3.10
- Remove stale drop_lt_af2.9 CI push trigger branch