### PR TITLE
Add Python 3.14 to test matrix for Apache Airflow 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Build and test
 on:
   push:
-    branches: ['main', 'python3.14']
+    branches: ['main']
   pull_request_target:
     branches: ['main']
   release:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Build and test
 on:
   push:
-    branches: ['main']
+    branches: ['main', 'python3.14']
   pull_request_target:
     branches: ['main']
   release:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
         airflow-version: [ "2.9", "2.10", "3.0", "3.1", "3.2" ]
         exclude:
           # Python 3.13 is only supported by Apache Airflow >= 3.0.
@@ -58,6 +58,15 @@ jobs:
             airflow-version: "2.9"
           - python-version: "3.13"
             airflow-version: "2.10"
+          # Python 3.14 is only supported by Apache Airflow >= 3.2.
+          - python-version: "3.14"
+            airflow-version: "2.9"
+          - python-version: "3.14"
+            airflow-version: "2.10"
+          - python-version: "3.14"
+            airflow-version: "3.0"
+          - python-version: "3.14"
+            airflow-version: "3.1"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -101,7 +110,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
         # TODO: Enable tests for others version of Airflow
         # https://github.com/astronomer/airflow-provider-fivetran-async/issues/166
         airflow-version: [ "2.9", "2.10", "3.0", "3.1", "3.2" ]
@@ -111,6 +120,15 @@ jobs:
             airflow-version: "2.9"
           - python-version: "3.13"
             airflow-version: "2.10"
+          # Python 3.14 is only supported by Apache Airflow >= 3.2.
+          - python-version: "3.14"
+            airflow-version: "2.9"
+          - python-version: "3.14"
+            airflow-version: "2.10"
+          - python-version: "3.14"
+            airflow-version: "3.0"
+          - python-version: "3.14"
+            airflow-version: "3.1"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Typing :: Typed",
 ]
 dependencies = [
@@ -83,6 +84,10 @@ airflow = ["2.9", "2.10", "3.0", "3.1", "3.2"]
 python = ["3.13"]
 airflow = ["3.0", "3.1", "3.2"]
 
+[[tool.hatch.envs.tests.matrix]]
+python = ["3.14"]
+airflow = ["3.2"]
+
 [tool.hatch.envs.tests.scripts]
 freeze = "pip freeze"
 static-check = "prek run --files fivetran_provider_async/*"
@@ -122,7 +127,7 @@ markers = ["integration"]
 
 [tool.black]
 line-length = 120
-target-version = ['py310', 'py311', 'py312', 'py313']
+target-version = ['py310', 'py311', 'py312', 'py313', 'py314']
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
Add Python 3.14 to test matrix for Apache Airflow 3.2

 - pyproject.toml: added "3.14" classifier, new matrix section python = ["3.14"] / airflow = ["3.2"], and py314 to     
  black's target-version                                                                                                
  - ci.yml: added "3.14" to both unit and integration test python-version lists, with four excludes to restrict it to   
  Airflow 3.2 only    

CI: https://github.com/astronomer/airflow-provider-fivetran-async/actions/runs/24434405973/job/71385417491?pr=232